### PR TITLE
Refactor DLABridging support helpers

### DIFF
--- a/DLABridging.xcodeproj/project.pbxproj
+++ b/DLABridging.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		161C9A982FA422F60067C095 /* DLABQueryInterfaceAny.h in Headers */ = {isa = PBXBuildFile; fileRef = 161C9A972FA422F60067C095 /* DLABQueryInterfaceAny.h */; };
 		161C9A9B2FA4231C0067C095 /* DLABVersionChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 161C9A9A2FA4231C0067C095 /* DLABVersionChecker.mm */; };
 		161C9A9C2FA4231C0067C095 /* DLABVersionChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 161C9A992FA4231C0067C095 /* DLABVersionChecker.h */; };
+		161C9B1F2FA8A5260067C095 /* DLABVideoBufferSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 161C9B1E2FA8A5260067C095 /* DLABVideoBufferSupport.h */; };
+		161C9B202FA8A5260067C095 /* DLABBridgingSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 161C9B1D2FA8A5260067C095 /* DLABBridgingSupport.h */; };
 		164BBCCE24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 164BBCCC24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.h */; };
 		164BBCCF24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.mm in Sources */ = {isa = PBXBuildFile; fileRef = 164BBCCD24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.mm */; };
 		164BBCD224CAB4090076EF54 /* DLABDeckControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 164BBCD024CAB4090076EF54 /* DLABDeckControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -67,6 +69,8 @@
 		161C9A972FA422F60067C095 /* DLABQueryInterfaceAny.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DLABQueryInterfaceAny.h; sourceTree = "<group>"; };
 		161C9A992FA4231C0067C095 /* DLABVersionChecker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DLABVersionChecker.h; sourceTree = "<group>"; };
 		161C9A9A2FA4231C0067C095 /* DLABVersionChecker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DLABVersionChecker.mm; sourceTree = "<group>"; };
+		161C9B1D2FA8A5260067C095 /* DLABBridgingSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DLABBridgingSupport.h; sourceTree = "<group>"; };
+		161C9B1E2FA8A5260067C095 /* DLABVideoBufferSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DLABVideoBufferSupport.h; sourceTree = "<group>"; };
 		164BBCCC24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DLABDeckControlStatusCallback.h; sourceTree = "<group>"; };
 		164BBCCD24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DLABDeckControlStatusCallback.mm; sourceTree = "<group>"; };
 		164BBCD024CAB4090076EF54 /* DLABDeckControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DLABDeckControl.h; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 				164C82AF1F514687001208BD /* DLABAudioSetting.h */,
 				164C82AE1F514687001208BD /* DLABAudioSetting+Internal.h */,
 				164C82B01F514687001208BD /* DLABAudioSetting.mm */,
+				161C9B1D2FA8A5260067C095 /* DLABBridgingSupport.h */,
 				164C82B21F514687001208BD /* DLABBrowser.h */,
 				164C82B11F514687001208BD /* DLABBrowser+Internal.h */,
 				164C82B31F514687001208BD /* DLABBrowser.mm */,
@@ -202,6 +207,7 @@
 				164EC8B3241E522F002FBF36 /* DLABFrameMetadata.h */,
 				164EC8B7241E524C002FBF36 /* DLABFrameMetadata+Internal.h */,
 				164EC8B4241E522F002FBF36 /* DLABFrameMetadata.mm */,
+				161C9B1E2FA8A5260067C095 /* DLABVideoBufferSupport.h */,
 				16B0BF17243BEE12004C2BDF /* DLABVideoConverter.h */,
 				16B0BF18243BEE12004C2BDF /* DLABVideoConverter.mm */,
 				164BBCD024CAB4090076EF54 /* DLABDeckControl.h */,
@@ -257,6 +263,8 @@
 				1656BF07241B6B4700E95D3B /* DLABProfileCallback.h in Headers */,
 				164C828A1F514632001208BD /* DLABridging.h in Headers */,
 				164BBCCE24CAA0AE0076EF54 /* DLABDeckControlStatusCallback.h in Headers */,
+				161C9B1F2FA8A5260067C095 /* DLABVideoBufferSupport.h in Headers */,
+				161C9B202FA8A5260067C095 /* DLABBridgingSupport.h in Headers */,
 				164BBCD224CAB4090076EF54 /* DLABDeckControl.h in Headers */,
 				164C82D51F514687001208BD /* DLABBrowser.h in Headers */,
 				164C82D71F514687001208BD /* DLABConstants.h in Headers */,

--- a/Source/DLABAudioSetting+Internal.h
+++ b/Source/DLABAudioSetting+Internal.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Utility to fill AudioStreamBasicDescription and CMAudioFormatDescription.
-
+ 
  @param aclData NSData* of AudioChannelLayout
  @param asbdData NSMutableData* of AudioStreamBasicDescription to fill
  @param channelCount mChannelsPerFrame for AudioStreamBasicDescription

--- a/Source/DLABAudioSetting.mm
+++ b/Source/DLABAudioSetting.mm
@@ -9,16 +9,14 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABAudioSetting+Internal.h>
+#import <DLABBridgingSupport.h>
 #import <AudioToolbox/AudioToolbox.h>
 
 @implementation DLABAudioSetting
 
 - (instancetype) init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    NSString *selectorString = NSStringFromSelector(@selector(initWithSampleType:channelCount:sampleRate:));
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+    DLABRaiseUnavailableInit(self, @selector(initWithSampleType:channelCount:sampleRate:));
     return nil;
 }
 
@@ -98,18 +96,7 @@
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    if (error) {
-        if (!description) description = @"unknown description";
-        if (!failureReason) failureReason = @"unknown failureReason";
-        
-        NSString *domain = @"com.MyCometG3.DLABridging.ErrorDomain";
-        NSInteger code = (NSInteger)result;
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
-                                   NSLocalizedFailureReasonErrorKey : failureReason,};
-        *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
-        return YES;
-    }
-    return NO;
+    return DLABAssignError(error, description, failureReason, (NSInteger)result);
 }
 
 /* =================================================================================== */
@@ -223,7 +210,7 @@
             // Configure AudioChannelLayout
             AudioChannelLayout* aclPtr = (AudioChannelLayout*)(aclData.mutableBytes);
             aclPtr->mChannelLayoutTag = tag;
-
+            
             // NOTE: validChannelCount <= channelCount, validSampleSize <= sampleSize
             result = [self fillAudioFormatDescriptionAndAsbdData:asbdData
                                                usingChannelCount:validChannelCount

--- a/Source/DLABBridgingSupport.h
+++ b/Source/DLABBridgingSupport.h
@@ -1,0 +1,426 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+
+#ifdef __cplusplus
+#import <DeckLinkAPI.h>
+#endif
+
+NS_INLINE NSString * _Nonnull DLABErrorDomain(void)
+{
+    return @"com.MyCometG3.DLABridging.ErrorDomain";
+}
+
+NS_INLINE NSString * _Nonnull DLABFunctionLineDescription(const char * _Nonnull functionName, int line)
+{
+    return [NSString stringWithFormat:@"%s (%d)", functionName, line];
+}
+
+NS_INLINE BOOL DLABAssignError(NSError * _Nullable * _Nullable error,
+                               NSString * _Nullable description,
+                               NSString * _Nullable failureReason,
+                               NSInteger code)
+{
+    if (error) {
+        if (!description) description = @"unknown description";
+        if (!failureReason) failureReason = @"unknown failureReason";
+        
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
+                                   NSLocalizedFailureReasonErrorKey : failureReason,};
+        *error = [NSError errorWithDomain:DLABErrorDomain() code:code userInfo:userInfo];
+        return YES;
+    }
+    return NO;
+}
+
+NS_INLINE void DLABRaiseUnavailableInit(id _Nonnull selfObject, SEL _Nonnull requiredSelector)
+{
+    NSString *classString = NSStringFromClass([selfObject class]);
+    NSString *selectorString = NSStringFromSelector(requiredSelector);
+    [NSException raise:NSGenericException
+                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+}
+
+NS_INLINE void DLABRaiseUnavailableSingletonInit(id _Nonnull selfObject, NSString * _Nonnull replacementText)
+{
+    NSString *classString = NSStringFromClass([selfObject class]);
+    [NSException raise:NSGenericException
+                format:@"Disabled. Use +[%@ %@] instead", classString, replacementText];
+}
+
+NS_INLINE void DLABDispatchSyncIfNeeded(dispatch_queue_t _Nullable queue, void * _Nullable key, dispatch_block_t _Nonnull block)
+{
+    if (queue) {
+        if (key && dispatch_get_specific(key)) {
+            block();
+        } else {
+            dispatch_sync(queue, block);
+        }
+    } else {
+        NSLog(@"ERROR: The queue is not available.");
+    }
+}
+
+NS_INLINE void DLABDispatchAsyncIfNeeded(dispatch_queue_t _Nullable queue, void * _Nullable key, dispatch_block_t _Nonnull block)
+{
+    if (queue) {
+        if (key && dispatch_get_specific(key)) {
+            block();
+        } else {
+            dispatch_async(queue, block);
+        }
+    } else {
+        NSLog(@"ERROR: The queue is not available.");
+    }
+}
+
+#ifdef __cplusplus
+template <typename Interface, typename KeyType>
+NS_INLINE NSNumber * _Nullable DLABGetFlagValue(Interface * _Nonnull iface,
+                                                KeyType key,
+                                                NSError * _Nullable * _Nullable error,
+                                                const char * _Nonnull functionName,
+                                                int lineNumber,
+                                                NSString * _Nullable failureReason)
+{
+    bool newValue = false;
+    HRESULT result = iface->GetFlag(key, &newValue);
+    if (result == S_OK) {
+        return @(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSNumber * _Nullable DLABGetIntValue(Interface * _Nonnull iface,
+                                               KeyType key,
+                                               NSError * _Nullable * _Nullable error,
+                                               const char * _Nonnull functionName,
+                                               int lineNumber,
+                                               NSString * _Nullable failureReason)
+{
+    int64_t newValue = 0;
+    HRESULT result = iface->GetInt(key, &newValue);
+    if (result == S_OK) {
+        return @(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSNumber * _Nullable DLABGetFloatValue(Interface * _Nonnull iface,
+                                                 KeyType key,
+                                                 NSError * _Nullable * _Nullable error,
+                                                 const char * _Nonnull functionName,
+                                                 int lineNumber,
+                                                 NSString * _Nullable failureReason)
+{
+    double newValue = 0;
+    HRESULT result = iface->GetFloat(key, &newValue);
+    if (result == S_OK) {
+        return @(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSString * _Nullable DLABGetStringValue(Interface * _Nonnull iface,
+                                                  KeyType key,
+                                                  NSError * _Nullable * _Nullable error,
+                                                  const char * _Nonnull functionName,
+                                                  int lineNumber,
+                                                  NSString * _Nullable failureReason)
+{
+    CFStringRef newValue = NULL;
+    HRESULT result = iface->GetString(key, &newValue);
+    if (result == S_OK) {
+        return (NSString *)CFBridgingRelease(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSNumber * _Nullable DLABGetFlagWithParam(Interface * _Nonnull iface,
+                                                    KeyType key,
+                                                    uint64_t param,
+                                                    NSError * _Nullable * _Nullable error,
+                                                    const char * _Nonnull functionName,
+                                                    int lineNumber,
+                                                    NSString * _Nullable failureReason)
+{
+    bool newValue = false;
+    HRESULT result = iface->GetFlagWithParam(key, param, &newValue);
+    if (result == S_OK) {
+        return @(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSNumber * _Nullable DLABGetIntWithParam(Interface * _Nonnull iface,
+                                                   KeyType key,
+                                                   uint64_t param,
+                                                   NSError * _Nullable * _Nullable error,
+                                                   const char * _Nonnull functionName,
+                                                   int lineNumber,
+                                                   NSString * _Nullable failureReason)
+{
+    int64_t newValue = 0;
+    HRESULT result = iface->GetIntWithParam(key, param, &newValue);
+    if (result == S_OK) {
+        return @(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSNumber * _Nullable DLABGetFloatWithParam(Interface * _Nonnull iface,
+                                                     KeyType key,
+                                                     uint64_t param,
+                                                     NSError * _Nullable * _Nullable error,
+                                                     const char * _Nonnull functionName,
+                                                     int lineNumber,
+                                                     NSString * _Nullable failureReason)
+{
+    double newValue = 0;
+    HRESULT result = iface->GetFloatWithParam(key, param, &newValue);
+    if (result == S_OK) {
+        return @(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE NSString * _Nullable DLABGetStringWithParam(Interface * _Nonnull iface,
+                                                      KeyType key,
+                                                      uint64_t param,
+                                                      NSError * _Nullable * _Nullable error,
+                                                      const char * _Nonnull functionName,
+                                                      int lineNumber,
+                                                      NSString * _Nullable failureReason)
+{
+    CFStringRef newValue = NULL;
+    HRESULT result = iface->GetStringWithParam(key, param, &newValue);
+    if (result == S_OK) {
+        return (NSString *)CFBridgingRelease(newValue);
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return nil;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetFlagValue(Interface * _Nonnull iface,
+                                KeyType key,
+                                bool value,
+                                NSError * _Nullable * _Nullable error,
+                                const char * _Nonnull functionName,
+                                int lineNumber,
+                                NSString * _Nullable failureReason)
+{
+    HRESULT result = iface->SetFlag(key, value);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetIntValue(Interface * _Nonnull iface,
+                               KeyType key,
+                               int64_t value,
+                               NSError * _Nullable * _Nullable error,
+                               const char * _Nonnull functionName,
+                               int lineNumber,
+                               NSString * _Nullable failureReason)
+{
+    HRESULT result = iface->SetInt(key, value);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetFloatValue(Interface * _Nonnull iface,
+                                 KeyType key,
+                                 double value,
+                                 NSError * _Nullable * _Nullable error,
+                                 const char * _Nonnull functionName,
+                                 int lineNumber,
+                                 NSString * _Nullable failureReason)
+{
+    HRESULT result = iface->SetFloat(key, value);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetStringValue(Interface * _Nonnull iface,
+                                  KeyType key,
+                                  NSString * _Nonnull value,
+                                  NSError * _Nullable * _Nullable error,
+                                  const char * _Nonnull functionName,
+                                  int lineNumber,
+                                  NSString * _Nullable failureReason)
+{
+    CFStringRef newValue = (CFStringRef)CFBridgingRetain(value);
+    HRESULT result = iface->SetString(key, newValue);
+    CFRelease(newValue);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetFlagWithParam(Interface * _Nonnull iface,
+                                    KeyType key,
+                                    uint64_t param,
+                                    bool value,
+                                    NSError * _Nullable * _Nullable error,
+                                    const char * _Nonnull functionName,
+                                    int lineNumber,
+                                    NSString * _Nullable failureReason)
+{
+    HRESULT result = iface->SetFlagWithParam(key, param, value);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetIntWithParam(Interface * _Nonnull iface,
+                                   KeyType key,
+                                   uint64_t param,
+                                   int64_t value,
+                                   NSError * _Nullable * _Nullable error,
+                                   const char * _Nonnull functionName,
+                                   int lineNumber,
+                                   NSString * _Nullable failureReason)
+{
+    HRESULT result = iface->SetIntWithParam(key, param, value);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetFloatWithParam(Interface * _Nonnull iface,
+                                     KeyType key,
+                                     uint64_t param,
+                                     double value,
+                                     NSError * _Nullable * _Nullable error,
+                                     const char * _Nonnull functionName,
+                                     int lineNumber,
+                                     NSString * _Nullable failureReason)
+{
+    HRESULT result = iface->SetFloatWithParam(key, param, value);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+
+template <typename Interface, typename KeyType>
+NS_INLINE BOOL DLABSetStringWithParam(Interface * _Nonnull iface,
+                                      KeyType key,
+                                      uint64_t param,
+                                      NSString * _Nonnull value,
+                                      NSError * _Nullable * _Nullable error,
+                                      const char * _Nonnull functionName,
+                                      int lineNumber,
+                                      NSString * _Nullable failureReason)
+{
+    CFStringRef newValue = (CFStringRef)CFBridgingRetain(value);
+    HRESULT result = iface->SetStringWithParam(key, param, newValue);
+    CFRelease(newValue);
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    DLABAssignError(error,
+                    DLABFunctionLineDescription(functionName, lineNumber),
+                    failureReason,
+                    (NSInteger)result);
+    return NO;
+}
+#endif

--- a/Source/DLABBrowser.mm
+++ b/Source/DLABBrowser.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABBrowser+Internal.h>
+#import <DLABBridgingSupport.h>
 #include <DLABQueryInterfaceAny.h>
 
 const char* kBrowserQueue = "DLABDevice.browserQueue";
@@ -184,13 +185,12 @@ const char* kBrowserQueue = "DLABDevice.browserQueue";
 {
     IDeckLinkAPIInformation* api = self.apiInformation;
     if (api) {
-        HRESULT result = E_FAIL;
-        BMDDeckLinkAPIInformationID cfgID = informationID;
-        bool newBoolValue = false;
-        result = api->GetFlag(cfgID, &newBoolValue);
-        if (!result) {
-            return @(newBoolValue);
-        }
+        return DLABGetFlagValue(api,
+                                (BMDDeckLinkAPIInformationID)informationID,
+                                nil,
+                                __PRETTY_FUNCTION__,
+                                __LINE__,
+                                nil);
     }
     return nil;
 }
@@ -199,13 +199,12 @@ const char* kBrowserQueue = "DLABDevice.browserQueue";
 {
     IDeckLinkAPIInformation* api = self.apiInformation;
     if (api) {
-        HRESULT result = E_FAIL;
-        BMDDeckLinkAPIInformationID cfgID = informationID;
-        int64_t newIntValue = false;
-        result = api->GetInt(cfgID, &newIntValue);
-        if (!result) {
-            return @(newIntValue);
-        }
+        return DLABGetIntValue(api,
+                               (BMDDeckLinkAPIInformationID)informationID,
+                               nil,
+                               __PRETTY_FUNCTION__,
+                               __LINE__,
+                               nil);
     }
     return nil;
 }
@@ -214,13 +213,12 @@ const char* kBrowserQueue = "DLABDevice.browserQueue";
 {
     IDeckLinkAPIInformation* api = self.apiInformation;
     if (api) {
-        HRESULT result = E_FAIL;
-        BMDDeckLinkAPIInformationID cfgID = informationID;
-        double newDoubleValue = false;
-        result = api->GetFloat(cfgID, &newDoubleValue);
-        if (!result) {
-            return @(newDoubleValue);
-        }
+        return DLABGetFloatValue(api,
+                                 (BMDDeckLinkAPIInformationID)informationID,
+                                 nil,
+                                 __PRETTY_FUNCTION__,
+                                 __LINE__,
+                                 nil);
     }
     return nil;
 }
@@ -229,13 +227,12 @@ const char* kBrowserQueue = "DLABDevice.browserQueue";
 {
     IDeckLinkAPIInformation* api = self.apiInformation;
     if (api) {
-        HRESULT result = E_FAIL;
-        BMDDeckLinkAPIInformationID cfgID = informationID;
-        CFStringRef newStringValue = NULL;
-        result = api->GetString(cfgID, &newStringValue);
-        if (!result) {
-            return (NSString*)CFBridgingRelease(newStringValue);
-        }
+        return DLABGetStringValue(api,
+                                  (BMDDeckLinkAPIInformationID)informationID,
+                                  nil,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  nil);
     }
     return nil;
 }
@@ -515,15 +512,7 @@ NS_INLINE BOOL getTwoIDs(IDeckLink* deckLink, int64_t *topologicalIDRef, int64_t
     NSParameterAssert(block);
     
     dispatch_queue_t queue = self.browserQueue; // Allow lazy instantiation
-    if (queue) {
-        if (browserQueueKey && dispatch_get_specific(browserQueueKey)) {
-            block();
-        } else {
-            dispatch_sync(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchSyncIfNeeded(queue, browserQueueKey, block);
 }
 
 @end

--- a/Source/DLABDeckControl.mm
+++ b/Source/DLABDeckControl.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABDeckControl+Internal.h>
+#import <DLABBridgingSupport.h>
 
 const char* kDeckQueue = "DLABDeckControl.deckQueue";
 
@@ -16,14 +17,62 @@ NSString* const kCurrentModeKey = @"currentMode";
 NSString* const kCurrentVTRControlStateKey = @"currentState";
 NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
+NS_INLINE BOOL DLABPerformDeckCommand(DLABDeckControl *self,
+                                      NSError **error,
+                                      const char *functionName,
+                                      int lineNumber,
+                                      NSString *failureReason,
+                                      HRESULT (^command)(IDeckLinkDeckControl *control))
+{
+    __block HRESULT result = E_FAIL;
+    IDeckLinkDeckControl *control = self.deckControl;
+    if (control) {
+        DLABDispatchSyncIfNeeded(self.deckQueue, self.deckQueueKey, ^{
+            result = command(control);
+        });
+    }
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:result
+            to:error];
+    return NO;
+}
+
+NS_INLINE BOOL DLABPerformDeckCommandWithStatusError(DLABDeckControl *self,
+                                                     NSError **error,
+                                                     const char *functionName,
+                                                     int lineNumber,
+                                                     NSString *failureReason,
+                                                     HRESULT (^command)(IDeckLinkDeckControl *control, BMDDeckControlError *deckError))
+{
+    __block HRESULT result = E_FAIL;
+    __block BMDDeckControlError deckError = bmdDeckControlNoError;
+    IDeckLinkDeckControl *control = self.deckControl;
+    if (control) {
+        DLABDispatchSyncIfNeeded(self.deckQueue, self.deckQueueKey, ^{
+            result = command(control, &deckError);
+        });
+    }
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:(NSInteger)deckError
+            to:error];
+    return NO;
+}
+
 @implementation DLABDeckControl
 
 - (instancetype) init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    NSString *selectorString = NSStringFromSelector(@selector(initWithDeckLink:));
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+    DLABRaiseUnavailableInit(self, @selector(initWithDeckLink:));
     return nil;
 }
 
@@ -91,29 +140,13 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 - (void) deck_sync:(dispatch_block_t)block
 {
     dispatch_queue_t queue = self.deckQueue;
-    if (queue) {
-        if (deckQueueKey && dispatch_get_specific(deckQueueKey)) {
-            block(); // do sync operation
-        } else {
-            dispatch_sync(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchSyncIfNeeded(queue, deckQueueKey, block);
 }
 
 - (void) deck_async:(dispatch_block_t)block
 {
     dispatch_queue_t queue = self.deckQueue;
-    if (queue) {
-        if (deckQueueKey && dispatch_get_specific(deckQueueKey)) {
-            block(); // do sync operation instead of async
-        } else {
-            dispatch_async(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchAsyncIfNeeded(queue, deckQueueKey, block);
 }
 
 /* =================================================================================== */
@@ -125,18 +158,7 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    if (error) {
-        if (!description) description = @"unknown description";
-        if (!failureReason) failureReason = @"unknown failureReason";
-        
-        NSString *domain = @"com.MyCometG3.DLABridging.ErrorDomain";
-        NSInteger code = (NSInteger)result;
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
-                                   NSLocalizedFailureReasonErrorKey : failureReason,};
-        *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
-        return YES;
-    }
-    return NO;
+    return DLABAssignError(error, description, failureReason, (NSInteger)result);
 }
 
 /* =================================================================================== */
@@ -186,45 +208,29 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
 - (BOOL) openWithTimebase:(CMTime)timebase dropFrame:(BOOL)dropFrame error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
     BMDTimeScale timeScale = (BMDTimeScale)timebase.timescale;
     BMDTimeValue timeValue = (BMDTimeValue)timebase.value;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->Open(timeScale, timeValue, dropFrame, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Open failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Open failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Open(timeScale, timeValue, dropFrame, deckError);
+    });
 }
 
 - (BOOL) closeWithStandby:(BOOL)standby error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->Close(standby);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Close failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommand(self,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkDeckControl::Close failed.",
+                                  ^HRESULT(IDeckLinkDeckControl *control) {
+        return control->Close(standby);
+    });
 }
 
 - (nullable NSNumber*) currentModeWithError:(NSError**)error
@@ -339,22 +345,14 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
 - (BOOL) standby:(BOOL)standbyOn error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->SetStandby(standbyOn);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::SetStandby failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommand(self,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkDeckControl::SetStandby failed.",
+                                  ^HRESULT(IDeckLinkDeckControl *control) {
+        return control->SetStandby(standbyOn);
+    });
 }
 
 - (BOOL) sendCommand:(NSData*)commandBuffer
@@ -368,257 +366,150 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
     uint32_t inBufferSize = (uint32_t)commandBuffer.length;
     uint8_t* outBuffer = (uint8_t*)responseBuffer.bytes;
     uint32_t outBufferSize = (uint32_t)responseBuffer.length;
-    __block HRESULT result = E_FAIL;
     __block uint32_t outDataSize = 0;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->SendCommand(inBuffer, inBufferSize,
-                                                   outBuffer, &outDataSize,
-                                                   outBufferSize, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::SendCommand failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::SendCommand failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->SendCommand(inBuffer, inBufferSize,
+                                    outBuffer, &outDataSize,
+                                    outBufferSize, deckError);
+    });
 }
 
 - (BOOL) playWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->Play(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Play failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Play failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Play(deckError);
+    });
 }
 
 - (BOOL) stopWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->Stop(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Stop failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Stop failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Stop(deckError);
+    });
 }
 
 - (BOOL) togglePlayStopWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->TogglePlayStop(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::TogglePlayStop failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::TogglePlayStop failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->TogglePlayStop(deckError);
+    });
 }
 
 - (BOOL) ejectWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->Eject(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Eject failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Eject failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Eject(deckError);
+    });
 }
 
 - (BOOL) goToTimecode:(DLABTimecodeBCD)timecode error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = self.deckControl->GoToTimecode(timecode, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::GoToTimecode failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::GoToTimecode failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->GoToTimecode(timecode, deckError);
+    });
 }
 
 - (BOOL) fastForwardWithViewTape:(BOOL)viewTape error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->FastForward(viewTape, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::FastForward failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::FastForward failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->FastForward(viewTape, deckError);
+    });
 }
 
 - (BOOL) rewindWithViewTape:(BOOL)viewTape error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->Rewind(viewTape, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Rewind failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Rewind failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Rewind(viewTape, deckError);
+    });
 }
 
 - (BOOL) stepForwardWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->StepForward(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::StepForward failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::StepForward failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->StepForward(deckError);
+    });
 }
 
 - (BOOL) stepBackWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->StepBack(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::StepBack failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::StepBack failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->StepBack(deckError);
+    });
 }
 
 - (BOOL) jogWithRate:(double)rate error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->Jog(rate, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Jog failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Jog failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Jog(rate, deckError);
+    });
 }
 
 - (BOOL) shuttleWithRate:(double)rate error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->Shuttle(rate, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Shuttle failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::Shuttle failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->Shuttle(rate, deckError);
+    });
 }
 
 - (nullable NSString*) timecodeStringWithError:(NSError**)error
@@ -703,22 +594,14 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
 - (BOOL) setPrerollSeconds:(uint32_t)prerollInSec error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->SetPreroll(prerollInSec);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::SetPreroll failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommand(self,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkDeckControl::SetPreroll failed.",
+                                  ^HRESULT(IDeckLinkDeckControl *control) {
+        return control->SetPreroll(prerollInSec);
+    });
 }
 
 - (nullable NSNumber*) prerollSecondsWithError:(NSError**)error
@@ -744,22 +627,14 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
 - (BOOL) setCaptureOffset:(int32_t)offsetFields error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->SetCaptureOffset(offsetFields);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::SetCaptureOffset failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommand(self,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkDeckControl::SetCaptureOffset failed.",
+                                  ^HRESULT(IDeckLinkDeckControl *control) {
+        return control->SetCaptureOffset(offsetFields);
+    });
 }
 
 - (nullable NSNumber*) captureOffsetWithError:(NSError**)error
@@ -785,22 +660,14 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
 - (BOOL) setExportOffset:(int32_t)offsetFields error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->SetExportOffset(offsetFields);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::SetExportOffset failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommand(self,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkDeckControl::SetExportOffset failed.",
+                                  ^HRESULT(IDeckLinkDeckControl *control) {
+        return control->SetExportOffset(offsetFields);
+    });
 }
 
 - (nullable NSNumber*) exportOffsetWithError:(NSError**)error
@@ -850,23 +717,14 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
             modeOpsFlags:(DLABDeckControlExportModeOps)flags
                    error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->StartExport(inTimecode, outTimecode, flags, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::StartExport failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::StartExport failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->StartExport(inTimecode, outTimecode, flags, deckError);
+    });
 }
 
 - (BOOL) startCaptureFrom:(DLABTimecodeBCD)inTimecode
@@ -874,23 +732,14 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
                   useVITC:(BOOL)useVITC
                     error:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->StartCapture(useVITC, inTimecode, outTimecode, &err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::StartCapture failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::StartCapture failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->StartCapture(useVITC, inTimecode, outTimecode, deckError);
+    });
 }
 
 - (nullable NSNumber*) deviceIDWithError:(NSError**)error
@@ -917,64 +766,38 @@ NSString* const kCurrentStatusFlagsKey = @"currentFlags";
 
 - (BOOL) abortWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->Abort();
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::Abort failed."
-              code:(NSInteger)result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommand(self,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkDeckControl::Abort failed.",
+                                  ^HRESULT(IDeckLinkDeckControl *control) {
+        return control->Abort();
+    });
 }
 
 - (BOOL) crashRecordStartWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->CrashRecordStart(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::CrashRecordStart failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::CrashRecordStart failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->CrashRecordStart(deckError);
+    });
 }
 
 - (BOOL) crashRecordStopWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block BMDDeckControlError err = bmdDeckControlNoError;
-    IDeckLinkDeckControl* control = self.deckControl;
-    if (control) {
-        [self deck_sync:^{
-            result = control->CrashRecordStop(&err);
-        }];
-    }
-    if (result == S_OK) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkDeckControl::CrashRecordStop failed."
-              code:(NSInteger)err // result
-                to:error];
-        return NO;
-    }
+    return DLABPerformDeckCommandWithStatusError(self,
+                                                 error,
+                                                 __PRETTY_FUNCTION__,
+                                                 __LINE__,
+                                                 @"IDeckLinkDeckControl::CrashRecordStop failed.",
+                                                 ^HRESULT(IDeckLinkDeckControl *control, BMDDeckControlError *deckError) {
+        return control->CrashRecordStop(deckError);
+    });
 }
 
 @end

--- a/Source/DLABDevice+Input.mm
+++ b/Source/DLABDevice+Input.mm
@@ -9,7 +9,74 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABDevice+Internal.h>
+#import <DLABBridgingSupport.h>
 #import <DLABQueryInterfaceAny.h>
+#import <DLABVideoBufferSupport.h>
+
+NS_INLINE BOOL DLABPerformInputCommand(DLABDevice *self,
+                                       NSError **error,
+                                       const char *functionName,
+                                       int lineNumber,
+                                       NSString *failureReason,
+                                       HRESULT (^command)(IDeckLinkInput *input))
+{
+    __block HRESULT result = E_FAIL;
+    
+    IDeckLinkInput *input = self.deckLinkInput;
+    if (!input) {
+        [self post:DLABFunctionLineDescription(functionName, lineNumber)
+            reason:@"IDeckLinkInput is not supported."
+              code:E_NOINTERFACE
+                to:error];
+        return NO;
+    }
+    
+    [self capture_sync:^{
+        result = command(input);
+    }];
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:result
+            to:error];
+    return NO;
+}
+
+NS_INLINE NSNumber * DLABInputUInt32Value(DLABDevice *self,
+                                          NSError **error,
+                                          const char *functionName,
+                                          int lineNumber,
+                                          NSString *failureReason,
+                                          HRESULT (^command)(IDeckLinkInput *input, uint32_t *value))
+{
+    __block HRESULT result = E_FAIL;
+    __block uint32_t value = 0;
+    
+    IDeckLinkInput *input = self.deckLinkInput;
+    if (!input) {
+        [self post:DLABFunctionLineDescription(functionName, lineNumber)
+            reason:@"IDeckLinkInput is not supported."
+              code:E_NOINTERFACE
+                to:error];
+        return nil;
+    }
+    
+    [self capture_sync:^{
+        result = command(input, &value);
+    }];
+    if (result == S_OK) {
+        return @(value);
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:result
+            to:error];
+    return nil;
+}
 
 /* =================================================================================== */
 // MARK: - input (internal)
@@ -178,92 +245,6 @@
 /* =================================================================================== */
 // MARK: Process Input videoFrame/audioPacket/Timecode
 /* =================================================================================== */
-
-NS_INLINE size_t pixelSizeForDL(IDeckLinkVideoFrame* videoFrame) {
-    size_t pixelSize = 0;   // For vImageCopyBuffer()
-    
-    BMDPixelFormat format = videoFrame->GetPixelFormat();
-    switch (format) {
-        case bmdFormat8BitYUV:
-            pixelSize = ceil( 4.0/2); break; // 4 bytes 2 pixels block
-        case bmdFormat10BitYUV:
-            pixelSize = ceil(16.0/6); break; // 16 bytes 6 pixels block
-        case bmdFormat8BitARGB:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat8BitBGRA:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat10BitRGB:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat12BitRGB:
-            pixelSize = ceil(36.0/8); break; // 36 bytes 8 pixel block
-        case bmdFormat12BitRGBLE:
-            pixelSize = ceil(36.0/8); break; // 36 bytes 8 pixel block
-        case bmdFormat10BitRGBXLE:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat10BitRGBX:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        default:
-            break;
-    }
-    return pixelSize;
-}
-
-NS_INLINE size_t pixelSizeForCV(CVPixelBufferRef pixelBuffer) {
-    size_t pixelSize = 0;   // For vImageCopyBuffer()
-    {
-        NSString* kBitsPerBlock = (__bridge NSString*)kCVPixelFormatBitsPerBlock;
-        NSString* kBlockWidth = (__bridge NSString*)kCVPixelFormatBlockWidth;
-        NSString* kBlockHeight = (__bridge NSString*)kCVPixelFormatBlockHeight;
-        
-        OSType pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);
-        CFDictionaryRef pfDict = CVPixelFormatDescriptionCreateWithPixelFormatType(kCFAllocatorDefault, pixelFormat);
-        NSDictionary* dict = CFBridgingRelease(pfDict);
-        
-        int numBitsPerBlock = ((NSNumber*)dict[kBitsPerBlock]).intValue;
-        int numWidthPerBlock = MAX(1,((NSNumber*)dict[kBlockWidth]).intValue);
-        int numHeightPerBlock = MAX(1,((NSNumber*)dict[kBlockHeight]).intValue);
-        int numPixelPerBlock = numWidthPerBlock * numHeightPerBlock;
-        if (numPixelPerBlock) {
-            pixelSize = ceil(numBitsPerBlock / numPixelPerBlock / 8.0);
-        }
-    }
-    return pixelSize;
-}
-
-NS_INLINE BOOL VideoBufferLockBaseAddress(IDeckLinkVideoFrame* videoFrame,
-                                          BMDBufferAccessFlags accessFlags,
-                                          IDeckLinkVideoBuffer** outVideoBuffer) {
-    if (!videoFrame || !outVideoBuffer) return NO;
-    *outVideoBuffer = NULL;
-    
-    IDeckLinkVideoBuffer* buf = NULL;
-    HRESULT hr = videoFrame->QueryInterface(IID_IDeckLinkVideoBuffer, (void**)&buf);
-    if (FAILED(hr)) return NO;
-    
-    hr = buf->StartAccess(accessFlags);
-    if (FAILED(hr)) {
-        buf->Release();
-        return NO;
-    }
-    
-    *outVideoBuffer = buf; // caller owns one ref
-    return YES;
-}
-
-NS_INLINE BOOL VideoBufferGetBaseAddress(IDeckLinkVideoBuffer* videoBuffer, void** pointer) {
-    if (!videoBuffer || !pointer) return NO;
-    *pointer = NULL;
-    
-    HRESULT hr = videoBuffer->GetBytes(pointer);
-    return SUCCEEDED(hr) && (*pointer != NULL);
-}
-
-NS_INLINE void VideoBufferUnlockBaseAddress(IDeckLinkVideoBuffer* videoBuffer,
-                                            BMDBufferAccessFlags accessFlags) {
-    if (!videoBuffer) return;
-    (void)videoBuffer->EndAccess(accessFlags);
-    videoBuffer->Release();
-}
 
 NS_INLINE BOOL copyBufferDLtoCV(DLABDevice* self, IDeckLinkVideoFrame* videoFrame, CVPixelBufferRef pixelBuffer) {
     assert(videoFrame && pixelBuffer);
@@ -899,13 +880,13 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
                                 uint32_t lineNumber = packet->GetLineNumber();
                                 uint8_t dataStreamIndex = packet->GetDataStreamIndex();
                                 // Only call GetDataSpace() if SDK 15.3+ is available
-
+                                
                                 DLABAncillaryDataSpace dataSpace = DLABAncillaryDataSpaceVANC;
-
+                                
                                 if (![DLABVersionChecker checkPre1503]) {
-
+                                    
                                     dataSpace = (DLABAncillaryDataSpace)packet->GetDataSpace();
-
+                                    
                                 }
                                 ready = inHandler(timingInfo,
                                                   did, sdid, lineNumber, dataStreamIndex,
@@ -1167,35 +1148,22 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
 {
     NSParameterAssert(setting);
     
-    __block HRESULT result = E_FAIL;
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        BMDDisplayMode displayMode = setting.displayMode;
-        BMDVideoInputFlags inputFlag = setting.inputFlag;
-        BMDPixelFormat format = setting.pixelFormat;
-        
-        [self capture_sync:^{
-            result = input->EnableVideoInput(displayMode, format, inputFlag);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
+    BMDDisplayMode displayMode = setting.displayMode;
+    BMDVideoInputFlags inputFlag = setting.inputFlag;
+    BMDPixelFormat format = setting.pixelFormat;
+    BOOL succeeded = DLABPerformInputCommand(self,
+                                             error,
+                                             __PRETTY_FUNCTION__,
+                                             __LINE__,
+                                             @"IDeckLinkInput::EnableVideoInput failed.",
+                                             ^HRESULT(IDeckLinkInput *input) {
+        return input->EnableVideoInput(displayMode, format, inputFlag);
+    });
+    if (succeeded) {
         self.inputVideoSettingW = setting;
         self.needsInputVideoConfigurationRefresh = TRUE;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::EnableVideoInput failed."
-              code:result
-                to:error];
-        return NO;
     }
+    return succeeded;
 }
 
 - (BOOL) enableVideoInputWithVideoSetting:(DLABVideoSetting*)setting
@@ -1215,60 +1183,30 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
 
 - (NSNumber*) getAvailableVideoFrameCountWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block uint32_t availableFrameCount = 0;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->GetAvailableVideoFrameCount(&availableFrameCount);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return nil;
-    }
-    
-    if (!result) {
-        return @(availableFrameCount);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::GetAvailableVideoFrameCount failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABInputUInt32Value(self,
+                                error,
+                                __PRETTY_FUNCTION__,
+                                __LINE__,
+                                @"IDeckLinkInput::GetAvailableVideoFrameCount failed.",
+                                ^HRESULT(IDeckLinkInput *input, uint32_t *value) {
+        return input->GetAvailableVideoFrameCount(value);
+    });
 }
 
 - (BOOL) disableVideoInputWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->DisableVideoInput();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
+    BOOL succeeded = DLABPerformInputCommand(self,
+                                             error,
+                                             __PRETTY_FUNCTION__,
+                                             __LINE__,
+                                             @"IDeckLinkInput::DisableVideoInput failed.",
+                                             ^HRESULT(IDeckLinkInput *input) {
+        return input->DisableVideoInput();
+    });
+    if (succeeded) {
         self.inputVideoSettingW = nil;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::DisableVideoInput failed."
-              code:result
-                to:error];
-        return NO;
     }
+    return succeeded;
 }
 
 /* =================================================================================== */
@@ -1301,35 +1239,21 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
         }
     }
     
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        BMDAudioSampleRate sampleRate = setting.sampleRate;
-        BMDAudioSampleType sampleType = setting.sampleType;
-        uint32_t channelCount = setting.channelCount;
-        
-        [self capture_sync:^{
-            result = input->EnableAudioInput(sampleRate, sampleType, channelCount);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
+    BMDAudioSampleRate sampleRate = setting.sampleRate;
+    BMDAudioSampleType sampleType = setting.sampleType;
+    uint32_t channelCount = setting.channelCount;
+    BOOL succeeded = DLABPerformInputCommand(self,
+                                             error,
+                                             __PRETTY_FUNCTION__,
+                                             __LINE__,
+                                             @"IDeckLinkInput::EnableAudioInput failed.",
+                                             ^HRESULT(IDeckLinkInput *input) {
+        return input->EnableAudioInput(sampleRate, sampleType, channelCount);
+    });
+    if (succeeded) {
         self.inputAudioSettingW = setting;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::EnableAudioInput failed."
-              code:result
-                to:error];
-        return NO;
     }
+    return succeeded;
 }
 
 - (BOOL) enableAudioInputWithSetting:(DLABAudioSetting*)setting
@@ -1349,60 +1273,30 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
 
 - (BOOL) disableAudioInputWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->DisableAudioInput();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
+    BOOL succeeded = DLABPerformInputCommand(self,
+                                             error,
+                                             __PRETTY_FUNCTION__,
+                                             __LINE__,
+                                             @"IDeckLinkInput::DisableAudioInput failed.",
+                                             ^HRESULT(IDeckLinkInput *input) {
+        return input->DisableAudioInput();
+    });
+    if (succeeded) {
         self.inputAudioSettingW = nil;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::DisableAudioInput failed."
-              code:result
-                to:error];
-        return NO;
     }
+    return succeeded;
 }
 
 - (NSNumber*) getAvailableAudioSampleFrameCountWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block uint32_t availableFrameCount = 0;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->GetAvailableAudioSampleFrameCount(&availableFrameCount);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return nil;
-    }
-    
-    if (!result) {
-        return @(availableFrameCount);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::GetAvailableAudioSampleFrameCount failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABInputUInt32Value(self,
+                                error,
+                                __PRETTY_FUNCTION__,
+                                __LINE__,
+                                @"IDeckLinkInput::GetAvailableAudioSampleFrameCount failed.",
+                                ^HRESULT(IDeckLinkInput *input, uint32_t *value) {
+        return input->GetAvailableAudioSampleFrameCount(value);
+    });
 }
 
 /* =================================================================================== */
@@ -1411,16 +1305,8 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
 
 - (BOOL) startStreamsWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self subscribeInput:YES];
-        
-        [self capture_sync:^{
-            result = input->StartStreams();
-        }];
-    } else {
+    IDeckLinkInput *input = self.deckLinkInput;
+    if (!input) {
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
             reason:@"IDeckLinkInput is not supported."
               code:E_NOINTERFACE
@@ -1428,99 +1314,56 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
         return NO;
     }
     
-    if (!result) {
+    [self subscribeInput:YES];
+    __block HRESULT result = E_FAIL;
+    [self capture_sync:^{
+        result = input->StartStreams();
+    }];
+    if (result == S_OK) {
         return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::StartStreams failed."
-              code:result
-                to:error];
-        return NO;
     }
+    
+    [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
+        reason:@"IDeckLinkInput::StartStreams failed."
+          code:result
+            to:error];
+    return NO;
 }
 
 - (BOOL) stopStreamsWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->StopStreams();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::StopStreams failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformInputCommand(self,
+                                   error,
+                                   __PRETTY_FUNCTION__,
+                                   __LINE__,
+                                   @"IDeckLinkInput::StopStreams failed.",
+                                   ^HRESULT(IDeckLinkInput *input) {
+        return input->StopStreams();
+    });
 }
 
 - (BOOL) flushStreamsWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->FlushStreams();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::FlushStreams failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformInputCommand(self,
+                                   error,
+                                   __PRETTY_FUNCTION__,
+                                   __LINE__,
+                                   @"IDeckLinkInput::FlushStreams failed.",
+                                   ^HRESULT(IDeckLinkInput *input) {
+        return input->FlushStreams();
+    });
 }
 
 - (BOOL) pauseStreamsWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkInput* input = self.deckLinkInput;
-    if (input) {
-        [self capture_sync:^{
-            result = input->PauseStreams();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkInput::PauseStreams failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABPerformInputCommand(self,
+                                   error,
+                                   __PRETTY_FUNCTION__,
+                                   __LINE__,
+                                   @"IDeckLinkInput::PauseStreams failed.",
+                                   ^HRESULT(IDeckLinkInput *input) {
+        return input->PauseStreams();
+    });
 }
 
 /* =================================================================================== */

--- a/Source/DLABDevice+Output.mm
+++ b/Source/DLABDevice+Output.mm
@@ -9,7 +9,107 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABDevice+Internal.h>
+#import <DLABBridgingSupport.h>
 #import <DLABQueryInterfaceAny.h>
+#import <DLABVideoBufferSupport.h>
+
+NS_INLINE BOOL DLABPerformOutputCommand(DLABDevice *self,
+                                        NSError **error,
+                                        const char *functionName,
+                                        int lineNumber,
+                                        NSString *failureReason,
+                                        HRESULT (^command)(IDeckLinkOutput *output))
+{
+    __block HRESULT result = E_FAIL;
+    
+    IDeckLinkOutput *output = self.deckLinkOutput;
+    if (!output) {
+        [self post:DLABFunctionLineDescription(functionName, lineNumber)
+            reason:@"IDeckLinkOutput is not supported."
+              code:E_NOINTERFACE
+                to:error];
+        return NO;
+    }
+    
+    [self playback_sync:^{
+        result = command(output);
+    }];
+    if (result == S_OK) {
+        return YES;
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:result
+            to:error];
+    return NO;
+}
+
+NS_INLINE NSNumber * DLABOutputUInt32Value(DLABDevice *self,
+                                           NSError **error,
+                                           const char *functionName,
+                                           int lineNumber,
+                                           NSString *failureReason,
+                                           HRESULT (^command)(IDeckLinkOutput *output, uint32_t *value))
+{
+    __block HRESULT result = E_FAIL;
+    __block uint32_t value = 0;
+    
+    IDeckLinkOutput *output = self.deckLinkOutput;
+    if (!output) {
+        [self post:DLABFunctionLineDescription(functionName, lineNumber)
+            reason:@"IDeckLinkOutput is not supported."
+              code:E_NOINTERFACE
+                to:error];
+        return nil;
+    }
+    
+    [self playback_sync:^{
+        result = command(output, &value);
+    }];
+    if (result == S_OK) {
+        return @(value);
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:result
+            to:error];
+    return nil;
+}
+
+NS_INLINE NSNumber * DLABOutputBoolValue(DLABDevice *self,
+                                         NSError **error,
+                                         const char *functionName,
+                                         int lineNumber,
+                                         NSString *failureReason,
+                                         HRESULT (^command)(IDeckLinkOutput *output, bool *value))
+{
+    __block HRESULT result = E_FAIL;
+    __block bool value = false;
+    
+    IDeckLinkOutput *output = self.deckLinkOutput;
+    if (!output) {
+        [self post:DLABFunctionLineDescription(functionName, lineNumber)
+            reason:@"IDeckLinkOutput is not supported."
+              code:E_NOINTERFACE
+                to:error];
+        return nil;
+    }
+    
+    [self playback_sync:^{
+        result = command(output, &value);
+    }];
+    if (result == S_OK) {
+        return @(value);
+    }
+    
+    [self post:DLABFunctionLineDescription(functionName, lineNumber)
+        reason:failureReason
+          code:result
+            to:error];
+    return nil;
+}
 
 /* =================================================================================== */
 // MARK: - output (internal)
@@ -167,92 +267,6 @@ NS_INLINE BMDAncillaryDataSpace DLABBMDAncillaryDataSpaceFromPublic(DLABAncillar
 /* =================================================================================== */
 // MARK: Process Output videoFrame/timecode
 /* =================================================================================== */
-
-NS_INLINE size_t pixelSizeForDL(IDeckLinkMutableVideoFrame* videoFrame) {
-    size_t pixelSize = 0;   // For vImageCopyBuffer()
-    
-    BMDPixelFormat format = videoFrame->GetPixelFormat();
-    switch (format) {
-        case bmdFormat8BitYUV:
-            pixelSize = ceil( 4.0/2); break; // 4 bytes 2 pixels block
-        case bmdFormat10BitYUV:
-            pixelSize = ceil(16.0/6); break; // 16 bytes 6 pixels block
-        case bmdFormat8BitARGB:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat8BitBGRA:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat10BitRGB:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat12BitRGB:
-            pixelSize = ceil(36.0/8); break; // 36 bytes 8 pixel block
-        case bmdFormat12BitRGBLE:
-            pixelSize = ceil(36.0/8); break; // 36 bytes 8 pixel block
-        case bmdFormat10BitRGBXLE:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        case bmdFormat10BitRGBX:
-            pixelSize = ceil( 4.0/1); break; // 4 bytes 1 pixel block
-        default:
-            break;
-    }
-    return pixelSize;
-}
-
-NS_INLINE size_t pixelSizeForCV(CVPixelBufferRef pixelBuffer) {
-    size_t pixelSize = 0;   // For vImageCopyBuffer()
-    {
-        NSString* kBitsPerBlock = (__bridge NSString*)kCVPixelFormatBitsPerBlock;
-        NSString* kBlockWidth = (__bridge NSString*)kCVPixelFormatBlockWidth;
-        NSString* kBlockHeight = (__bridge NSString*)kCVPixelFormatBlockHeight;
-        
-        OSType pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);
-        CFDictionaryRef pfDict = CVPixelFormatDescriptionCreateWithPixelFormatType(kCFAllocatorDefault, pixelFormat);
-        NSDictionary* dict = CFBridgingRelease(pfDict);
-        
-        int numBitsPerBlock = ((NSNumber*)dict[kBitsPerBlock]).intValue;
-        int numWidthPerBlock = MAX(1,((NSNumber*)dict[kBlockWidth]).intValue);
-        int numHeightPerBlock = MAX(1,((NSNumber*)dict[kBlockHeight]).intValue);
-        int numPixelPerBlock = numWidthPerBlock * numHeightPerBlock;
-        if (numPixelPerBlock) {
-            pixelSize = ceil(numBitsPerBlock / numPixelPerBlock / 8.0);
-        }
-    }
-    return pixelSize;
-}
-
-NS_INLINE BOOL VideoBufferLockBaseAddress(IDeckLinkMutableVideoFrame* videoFrame,
-                                          BMDBufferAccessFlags accessFlags,
-                                          IDeckLinkVideoBuffer** outVideoBuffer) {
-    if (!videoFrame || !outVideoBuffer) return NO;
-    *outVideoBuffer = NULL;
-    
-    IDeckLinkVideoBuffer* buf = NULL;
-    HRESULT hr = videoFrame->QueryInterface(IID_IDeckLinkVideoBuffer, (void**)&buf);
-    if (FAILED(hr)) return NO;
-    
-    hr = buf->StartAccess(accessFlags);
-    if (FAILED(hr)) {
-        buf->Release();
-        return NO;
-    }
-    
-    *outVideoBuffer = buf; // caller owns one ref
-    return YES;
-}
-
-NS_INLINE BOOL VideoBufferGetBaseAddress(IDeckLinkVideoBuffer* videoBuffer, void** pointer) {
-    if (!videoBuffer || !pointer) return NO;
-    *pointer = NULL;
-    
-    HRESULT hr = videoBuffer->GetBytes(pointer);
-    return SUCCEEDED(hr) && (*pointer != NULL);
-}
-
-NS_INLINE void VideoBufferUnlockBaseAddress(IDeckLinkVideoBuffer* videoBuffer,
-                                            BMDBufferAccessFlags accessFlags) {
-    if (!videoBuffer) return;
-    (void)videoBuffer->EndAccess(accessFlags);
-    videoBuffer->Release();
-}
 
 NS_INLINE BOOL copyBufferCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, IDeckLinkMutableVideoFrame* videoFrame) {
     assert(pixelBuffer && videoFrame);
@@ -637,19 +651,19 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
                         NSData* data = outHandler(timingInfo,
                                                   &did, &sdid, &lineNumber, &dataStreamIndex, &dataSpace);
                         if (data) {
-
+                            
                             // For SDK < 15.3, force dataSpace to VANC (only SDK 15.3+ supports dataSpace)
-
+                            
                             DLABAncillaryDataSpace effectiveDataSpace = dataSpace;
-
+                            
                             if ([DLABVersionChecker checkPre1503]) {
-
+                                
                                 effectiveDataSpace = DLABAncillaryDataSpaceVANC;
-
+                                
                             }
-
+                            
                             HRESULT ret = packet->Update(did, sdid, lineNumber, dataStreamIndex,
-
+                                                         
                                                          DLABBMDAncillaryDataSpaceFromPublic(effectiveDataSpace), data);
                             if (ret == S_OK) {
                                 ret = frameAncillaryPackets->AttachPacket(packet);
@@ -864,31 +878,14 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
 
 - (NSNumber*) isScheduledPlaybackRunningWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    __block bool newBoolValue = FALSE;
-    
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->IsScheduledPlaybackRunning(&newBoolValue);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return nil;
-    }
-    
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::IsScheduledPlaybackRunning failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABOutputBoolValue(self,
+                               error,
+                               __PRETTY_FUNCTION__,
+                               __LINE__,
+                               @"IDeckLinkOutput::IsScheduledPlaybackRunning failed.",
+                               ^HRESULT(IDeckLinkOutput *output, bool *value) {
+        return output->IsScheduledPlaybackRunning(value);
+    });
 }
 
 - (BOOL) setOutputScreenPreviewToView:(NSView*)parentView
@@ -942,34 +939,22 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
 {
     NSParameterAssert(setting);
     
-    __block HRESULT result = E_FAIL;
     BMDDisplayMode displayMode = setting.displayMode;
     BMDVideoOutputFlags outputFlag = setting.outputFlag;
-    
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->EnableVideoOutput(displayMode, outputFlag);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
+    BOOL succeeded = DLABPerformOutputCommand(self,
+                                              error,
+                                              __PRETTY_FUNCTION__,
+                                              __LINE__,
+                                              @"IDeckLinkOutput::EnableVideoOutput failed.",
+                                              ^HRESULT(IDeckLinkOutput *output) {
+        return output->EnableVideoOutput(displayMode, outputFlag);
+    });
+    if (succeeded) {
         self.outputVideoSettingW = setting;
-        return YES;
     } else {
         self.outputVideoSettingW = nil;
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::EnableVideoOutput failed."
-              code:result
-                to:error];
-        return NO;
     }
+    return succeeded;
 }
 
 - (BOOL) enableVideoOutputWithVideoSetting:(DLABVideoSetting*)setting
@@ -989,31 +974,18 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
 
 - (BOOL) disableVideoOutputWithError:(NSError**)error
 {
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->DisableVideoOutput();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
+    BOOL succeeded = DLABPerformOutputCommand(self,
+                                              error,
+                                              __PRETTY_FUNCTION__,
+                                              __LINE__,
+                                              @"IDeckLinkOutput::DisableVideoOutput failed.",
+                                              ^HRESULT(IDeckLinkOutput *output) {
+        return output->DisableVideoOutput();
+    });
+    if (succeeded) {
         self.outputVideoSettingW = nil;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::DisableVideoOutput failed."
-              code:result
-                to:error];
-        return NO;
     }
+    return succeeded;
 }
 
 static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVideoFrame *outFrame, NSInteger displayTime, NSInteger frameDuration, NSInteger timeScale) {
@@ -1055,6 +1027,166 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
     }
     
     return frameMetadata;
+}
+
+- (NSNumber*) getBufferedVideoFrameCountWithError:(NSError**)error
+{
+    return DLABOutputUInt32Value(self,
+                                 error,
+                                 __PRETTY_FUNCTION__,
+                                 __LINE__,
+                                 @"IDeckLinkOutput::GetBufferedVideoFrameCount failed.",
+                                 ^HRESULT(IDeckLinkOutput *output, uint32_t *value) {
+        return output->GetBufferedVideoFrameCount(value);
+    });
+}
+
+/* =================================================================================== */
+// MARK: Audio
+/* =================================================================================== */
+
+- (BOOL) enableAudioOutputWithAudioSetting:(DLABAudioSetting*)setting
+                                     error:(NSError**)error
+{
+    NSParameterAssert(setting);
+    
+    if (self.swapHDMICh3AndCh4OnOutput != nil) {
+        NSError *err = nil;
+        BOOL newValue = self.swapHDMICh3AndCh4OnOutput.boolValue;
+        DLABConfiguration key = DLABConfigurationSwapHDMICh3AndCh4OnOutput;
+        
+        // Verify if SwapHDMICh3AndCh4 flag is available on this device
+        [self boolValueForConfiguration:key error:&err];
+        if (!err) {
+            // Update accordingly
+            [self setBoolValue:newValue forConfiguration:key error:&err];
+        }
+        
+        if (err) {
+            [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
+                reason:@"bmdDeckLinkConfigSwapHDMICh3AndCh4OnOutput flag is not supported."
+                  code:E_NOTIMPL
+                    to:error];
+            return NO;
+        }
+    }
+    
+    BMDAudioSampleType sampleType = setting.sampleType;
+    uint32_t channelCount = setting.channelCount;
+    BOOL succeeded = DLABPerformOutputCommand(self,
+                                              error,
+                                              __PRETTY_FUNCTION__,
+                                              __LINE__,
+                                              @"IDeckLinkOutput::EnableAudioOutput failed.",
+                                              ^HRESULT(IDeckLinkOutput *output) {
+        return output->EnableAudioOutput(DLABAudioSampleRate48kHz,
+                                         sampleType,
+                                         channelCount,
+                                         DLABAudioOutputStreamTypeContinuous);
+    });
+    if (succeeded) {
+        self.outputAudioSettingW = setting;
+    }
+    return succeeded;
+}
+
+- (BOOL) disableAudioOutputWithError:(NSError**)error
+{
+    BOOL succeeded = DLABPerformOutputCommand(self,
+                                              error,
+                                              __PRETTY_FUNCTION__,
+                                              __LINE__,
+                                              @"IDeckLinkOutput::DisableAudioOutput failed.",
+                                              ^HRESULT(IDeckLinkOutput *output) {
+        return output->DisableAudioOutput();
+    });
+    if (succeeded) {
+        self.outputAudioSettingW = nil;
+    }
+    return succeeded;
+}
+
+- (NSNumber*) getBufferedAudioSampleFrameCountWithError:(NSError**)error;
+{
+    return DLABOutputUInt32Value(self,
+                                 error,
+                                 __PRETTY_FUNCTION__,
+                                 __LINE__,
+                                 @"IDeckLinkOutput::GetBufferedAudioSampleFrameCount failed.",
+                                 ^HRESULT(IDeckLinkOutput *output, uint32_t *value) {
+        return output->GetBufferedAudioSampleFrameCount(value);
+    });
+}
+
+- (BOOL) flushBufferedAudioSamplesWithError:(NSError**)error
+{
+    return DLABPerformOutputCommand(self,
+                                    error,
+                                    __PRETTY_FUNCTION__,
+                                    __LINE__,
+                                    @"IDeckLinkOutput::FlushBufferedAudioSamples failed.",
+                                    ^HRESULT(IDeckLinkOutput *output) {
+        return output->FlushBufferedAudioSamples();
+    });
+}
+
+- (BOOL) beginAudioPrerollWithError:(NSError**)error
+{
+    return DLABPerformOutputCommand(self,
+                                    error,
+                                    __PRETTY_FUNCTION__,
+                                    __LINE__,
+                                    @"IDeckLinkOutput::BeginAudioPreroll failed.",
+                                    ^HRESULT(IDeckLinkOutput *output) {
+        return output->BeginAudioPreroll();
+    });
+}
+
+- (BOOL) endAudioPrerollWithError:(NSError**)error
+{
+    return DLABPerformOutputCommand(self,
+                                    error,
+                                    __PRETTY_FUNCTION__,
+                                    __LINE__,
+                                    @"IDeckLinkOutput::EndAudioPreroll failed.",
+                                    ^HRESULT(IDeckLinkOutput *output) {
+        return output->EndAudioPreroll();
+    });
+}
+
+/* =================================================================================== */
+// MARK: Stream
+/* =================================================================================== */
+
+- (BOOL) startScheduledPlaybackAtTime:(NSUInteger)startTime
+                          inTimeScale:(NSUInteger)timeScale
+                                error:(NSError**)error
+{
+    NSParameterAssert(timeScale);
+    
+    IDeckLinkOutput *output = self.deckLinkOutput;
+    if (!output) {
+        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
+            reason:@"IDeckLinkOutput is not supported."
+              code:E_NOINTERFACE
+                to:error];
+        return NO;
+    }
+    
+    [self subscribeOutput:YES];
+    __block HRESULT result = E_FAIL;
+    [self playback_sync:^{
+        result = output->StartScheduledPlayback(startTime, timeScale, 1.0);
+    }];
+    if (result == S_OK) {
+        return YES;
+    } else {
+        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
+            reason:@"IDeckLinkOutput::StartScheduledPlayback failed."
+              code:result
+                to:error];
+        return NO;
+    }
 }
 
 - (BOOL) instantPlaybackOfPixelBuffer:(CVPixelBufferRef)pixelBuffer
@@ -1268,96 +1400,6 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
     }
 }
 
-- (NSNumber*) getBufferedVideoFrameCountWithError:(NSError**)error
-{
-    __block HRESULT result = E_FAIL;
-    __block uint32_t bufferedFrameCount = 0;
-    
-    IDeckLinkOutput *output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->GetBufferedVideoFrameCount(&bufferedFrameCount);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return nil;
-    }
-    
-    if (!result) {
-        return @(bufferedFrameCount);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::GetBufferedVideoFrameCount failed."
-              code:result
-                to:error];
-        return nil;
-    }
-}
-
-/* =================================================================================== */
-// MARK: Audio
-/* =================================================================================== */
-
-- (BOOL) enableAudioOutputWithAudioSetting:(DLABAudioSetting*)setting
-                                     error:(NSError**)error
-{
-    NSParameterAssert(setting);
-    
-    if (self.swapHDMICh3AndCh4OnOutput != nil) {
-        NSError *err = nil;
-        BOOL newValue = self.swapHDMICh3AndCh4OnOutput.boolValue;
-        DLABConfiguration key = DLABConfigurationSwapHDMICh3AndCh4OnOutput;
-        
-        // Verify if SwapHDMICh3AndCh4 flag is available on this device
-        [self boolValueForConfiguration:key error:&err];
-        if (!err) {
-            // Update accordingly
-            [self setBoolValue:newValue forConfiguration:key error:&err];
-        }
-        
-        if (err) {
-            [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                reason:@"bmdDeckLinkConfigSwapHDMICh3AndCh4OnOutput flag is not supported."
-                  code:E_NOTIMPL
-                    to:error];
-            return NO;
-        }
-    }
-    
-    __block HRESULT result = E_FAIL;
-    BMDAudioSampleType sampleType = setting.sampleType;
-    uint32_t channelCount = setting.channelCount;
-    
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->EnableAudioOutput(DLABAudioSampleRate48kHz,
-                                               sampleType,
-                                               channelCount,
-                                               DLABAudioOutputStreamTypeContinuous);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        self.outputAudioSettingW = setting;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::EnableAudioOutput failed."
-              code:result
-                to:error];
-        return NO;
-    }
-}
 
 - (BOOL) enableAudioOutputWithAudioSetting:(DLABAudioSetting*)setting
                                   onSwitch:(DLABAudioOutputSwitch)audioOutputSwitch
@@ -1375,34 +1417,6 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
 }
 
 
-- (BOOL) disableAudioOutputWithError:(NSError**)error
-{
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->DisableAudioOutput();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        self.outputAudioSettingW = nil;
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::DisableAudioOutput failed."
-              code:result
-                to:error];
-        return NO;
-    }
-}
 
 - (BOOL) instantPlaybackOfAudioBufferList:(AudioBufferList*)audioBufferList
                              writtenCount:(NSUInteger*)sampleFramesWritten
@@ -1550,62 +1564,6 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
     } else {
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
             reason:@"IDeckLinkOutput::WriteAudioSamplesSync failed."
-              code:result
-                to:error];
-        return NO;
-    }
-}
-
-- (BOOL) beginAudioPrerollWithError:(NSError**)error
-{
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkOutput *output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->BeginAudioPreroll();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::BeginAudioPreroll failed."
-              code:result
-                to:error];
-        return NO;
-    }
-}
-
-- (BOOL) endAudioPrerollWithError:(NSError**)error
-{
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkOutput *output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->EndAudioPreroll();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::EndAudioPreroll failed."
               code:result
                 to:error];
         return NO;
@@ -1772,101 +1730,6 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
     } else {
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
             reason:@"IDeckLinkOutput::ScheduleAudioSamples failed."
-              code:result
-                to:error];
-        return NO;
-    }
-}
-
-- (NSNumber*) getBufferedAudioSampleFrameCountWithError:(NSError**)error;
-{
-    __block HRESULT result = E_FAIL;
-    __block uint32_t bufferedFrameCount = 0;
-    
-    IDeckLinkOutput *output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->GetBufferedAudioSampleFrameCount(&bufferedFrameCount);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return nil;
-    }
-    
-    if (!result) {
-        return @(bufferedFrameCount);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::GetBufferedAudioSampleFrameCount failed."
-              code:result
-                to:error];
-        return nil;
-    }
-}
-
-- (BOOL) flushBufferedAudioSamplesWithError:(NSError**)error
-{
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkOutput *output = self.deckLinkOutput;
-    if (output) {
-        [self playback_sync:^{
-            result = output->FlushBufferedAudioSamples();
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::FlushBufferedAudioSamples failed."
-              code:result
-                to:error];
-        return NO;
-    }
-}
-
-/* =================================================================================== */
-// MARK: Stream
-/* =================================================================================== */
-
-- (BOOL) startScheduledPlaybackAtTime:(NSUInteger)startTime
-                          inTimeScale:(NSUInteger)timeScale
-                                error:(NSError**)error
-{
-    NSParameterAssert(timeScale);
-    
-    __block HRESULT result = E_FAIL;
-    
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output) {
-        [self subscribeOutput:YES];
-        
-        [self playback_sync:^{
-            result = output->StartScheduledPlayback(startTime, timeScale, 1.0);
-        }];
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput is not supported."
-              code:E_NOINTERFACE
-                to:error];
-        return NO;
-    }
-    
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkOutput::StartScheduledPlayback failed."
               code:result
                 to:error];
         return NO;

--- a/Source/DLABDevice.mm
+++ b/Source/DLABDevice.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABDevice+Internal.h>
+#import <DLABBridgingSupport.h>
 #import <DLABQueryInterfaceAny.h>
 #import <DLABVersionChecker.h>
 
@@ -20,10 +21,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 
 - (instancetype) init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    NSString *selectorString = NSStringFromSelector(@selector(initWithDeckLink:));
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+    DLABRaiseUnavailableInit(self, @selector(initWithDeckLink:));
     return nil;
 }
 
@@ -37,7 +35,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         IDeckLinkConfiguration* configuration = NULL;
         IDeckLinkStatus* status = NULL;
         IDeckLinkNotification* notification = NULL;
-
+        
         HRESULT err1 = DLABQueryInterfaceAny(newDeckLink, &profileAttributes,
                                              IID_IDeckLinkProfileAttributes,
                                              IID_IDeckLinkProfileAttributes_v15_3_1);
@@ -50,7 +48,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         HRESULT err4 = DLABQueryInterfaceAny(newDeckLink, &notification,
                                              IID_IDeckLinkNotification,
                                              IID_IDeckLinkNotification_v15_3_1);
-
+        
         if (FAILED(err1) || FAILED(err2) || FAILED(err3) || FAILED(err4)) {
             if (profileAttributes) profileAttributes->Release();
             if (configuration) configuration->Release();
@@ -58,7 +56,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
             if (notification) notification->Release();
             return nil;
         }
-
+        
         _deckLinkProfileAttributes = profileAttributes;
         _deckLinkConfiguration = configuration;
         _deckLinkStatus = status;
@@ -489,57 +487,25 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 - (void) delegate_sync:(dispatch_block_t) block
 {
     dispatch_queue_t queue = self.delegateQueue;
-    if (queue) {
-        if (delegateQueueKey && dispatch_get_specific(delegateQueueKey)) {
-            block(); // do sync operation
-        } else {
-            dispatch_sync(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchSyncIfNeeded(queue, delegateQueueKey, block);
 }
 
 - (void) delegate_async:(dispatch_block_t) block
 {
     dispatch_queue_t queue = self.delegateQueue;
-    if (queue) {
-        if (delegateQueueKey && dispatch_get_specific(delegateQueueKey)) {
-            block(); // do sync operation instead of async
-        } else {
-            dispatch_async(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchAsyncIfNeeded(queue, delegateQueueKey, block);
 }
 
 - (void) playback_sync:(dispatch_block_t) block
 {
     dispatch_queue_t queue = self.playbackQueue;
-    if (queue) {
-        if (playbackQueueKey && dispatch_get_specific(playbackQueueKey)) {
-            block();
-        } else {
-            dispatch_sync(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchSyncIfNeeded(queue, playbackQueueKey, block);
 }
 
 - (void) capture_sync:(dispatch_block_t) block
 {
     dispatch_queue_t queue = self.captureQueue;
-    if (queue) {
-        if (captureQueueKey && dispatch_get_specific(captureQueueKey)) {
-            block();
-        } else {
-            dispatch_sync(queue, block);
-        }
-    } else {
-        NSLog(@"ERROR: The queue is not available.");
-    }
+    DLABDispatchSyncIfNeeded(queue, captureQueueKey, block);
 }
 
 /* =================================================================================== */
@@ -551,18 +517,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    if (error) {
-        if (!description) description = @"unknown description";
-        if (!failureReason) failureReason = @"unknown failureReason";
-        
-        NSString *domain = @"com.MyCometG3.DLABridging.ErrorDomain";
-        NSInteger code = (NSInteger)result;
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
-                                   NSLocalizedFailureReasonErrorKey : failureReason,};
-        *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
-        return YES;
-    }
-    return NO;
+    return DLABAssignError(error, description, failureReason, (NSInteger)result);
 }
 
 /* =================================================================================== */
@@ -1057,19 +1012,12 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         return nil;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    bool newBoolValue = false;
-    result = _deckLinkProfileAttributes->GetFlag(attr, &newBoolValue);
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetFlag failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFlagValue(_deckLinkProfileAttributes,
+                            (BMDDeckLinkAttributeID)attributeID,
+                            error,
+                            __PRETTY_FUNCTION__,
+                            __LINE__,
+                            @"IDeckLinkAttributes::GetFlag failed.");
 }
 
 - (NSNumber*) intValueForAttribute:(DLABAttribute) attributeID
@@ -1081,19 +1029,12 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         return nil;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    int64_t newIntValue = 0;
-    result = _deckLinkProfileAttributes->GetInt(attr, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetInt failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntValue(_deckLinkProfileAttributes,
+                           (BMDDeckLinkAttributeID)attributeID,
+                           error,
+                           __PRETTY_FUNCTION__,
+                           __LINE__,
+                           @"IDeckLinkAttributes::GetInt failed.");
 }
 
 - (NSNumber*) doubleValueForAttribute:(DLABAttribute) attributeID
@@ -1105,19 +1046,12 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         return nil;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    double newDoubleValue = 0;
-    result = _deckLinkProfileAttributes->GetFloat(attr, &newDoubleValue);
-    if (!result) {
-        return @(newDoubleValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetFloat failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFloatValue(_deckLinkProfileAttributes,
+                             (BMDDeckLinkAttributeID)attributeID,
+                             error,
+                             __PRETTY_FUNCTION__,
+                             __LINE__,
+                             @"IDeckLinkAttributes::GetFloat failed.");
 }
 
 - (NSString*) stringValueForAttribute:(DLABAttribute) attributeID
@@ -1129,19 +1063,12 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         return nil;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    CFStringRef newStringValue = NULL;
-    result = _deckLinkProfileAttributes->GetString(attr, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetString failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringValue(_deckLinkProfileAttributes,
+                              (BMDDeckLinkAttributeID)attributeID,
+                              error,
+                              __PRETTY_FUNCTION__,
+                              __LINE__,
+                              @"IDeckLinkAttributes::GetString failed.");
 }
 
 /* =================================================================================== */
@@ -1151,149 +1078,97 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 - (NSNumber*) boolValueForConfiguration:(DLABConfiguration)configurationID
                                   error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    bool newBoolValue = false;
-    result = _deckLinkConfiguration->GetFlag(conf, &newBoolValue);
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetFlag failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFlagValue(_deckLinkConfiguration,
+                            (BMDDeckLinkConfigurationID)configurationID,
+                            error,
+                            __PRETTY_FUNCTION__,
+                            __LINE__,
+                            @"IDeckLinkConfiguration::GetFlag failed.");
 }
 
 - (NSNumber*) intValueForConfiguration:(DLABConfiguration)configurationID
                                  error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    int64_t newIntValue = 0;
-    result = _deckLinkConfiguration->GetInt(conf, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetInt failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntValue(_deckLinkConfiguration,
+                           (BMDDeckLinkConfigurationID)configurationID,
+                           error,
+                           __PRETTY_FUNCTION__,
+                           __LINE__,
+                           @"IDeckLinkConfiguration::GetInt failed.");
 }
 
 - (NSNumber*) doubleValueForConfiguration:(DLABConfiguration)configurationID
                                     error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    double newDoubleValue = 0;
-    result = _deckLinkConfiguration->GetFloat(conf, &newDoubleValue);
-    if (!result) {
-        return @(newDoubleValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetFloat failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFloatValue(_deckLinkConfiguration,
+                             (BMDDeckLinkConfigurationID)configurationID,
+                             error,
+                             __PRETTY_FUNCTION__,
+                             __LINE__,
+                             @"IDeckLinkConfiguration::GetFloat failed.");
 }
 
 - (NSString*) stringValueForConfiguration:(DLABConfiguration)configurationID
                                     error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    CFStringRef newStringValue = NULL;
-    result = _deckLinkConfiguration->GetString(conf, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetString failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringValue(_deckLinkConfiguration,
+                              (BMDDeckLinkConfigurationID)configurationID,
+                              error,
+                              __PRETTY_FUNCTION__,
+                              __LINE__,
+                              @"IDeckLinkConfiguration::GetString failed.");
 }
 
 - (NSNumber*) boolValueForConfiguration:(DLABConfiguration)configurationID
                               withParam:(NSUInteger)param
                                   error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    bool newBoolValue = false;
-    result = _deckLinkConfiguration->GetFlagWithParam(conf, (uint64_t)param, &newBoolValue);
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetFlagWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFlagWithParam(_deckLinkConfiguration,
+                                (BMDDeckLinkConfigurationID)configurationID,
+                                (uint64_t)param,
+                                error,
+                                __PRETTY_FUNCTION__,
+                                __LINE__,
+                                @"IDeckLinkConfiguration::GetFlagWithParam failed.");
 }
 
 - (NSNumber*) intValueForConfiguration:(DLABConfiguration)configurationID
                              withParam:(NSUInteger)param
                                  error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    int64_t newIntValue = 0;
-    result = _deckLinkConfiguration->GetIntWithParam(conf, (uint64_t)param, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetIntWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntWithParam(_deckLinkConfiguration,
+                               (BMDDeckLinkConfigurationID)configurationID,
+                               (uint64_t)param,
+                               error,
+                               __PRETTY_FUNCTION__,
+                               __LINE__,
+                               @"IDeckLinkConfiguration::GetIntWithParam failed.");
 }
 
 - (NSNumber*) doubleValueForConfiguration:(DLABConfiguration)configurationID
                                 withParam:(NSUInteger)param
                                     error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    double newDoubleValue = 0;
-    result = _deckLinkConfiguration->GetFloatWithParam(conf, (uint64_t)param, &newDoubleValue);
-    if (!result) {
-        return @(newDoubleValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetFloatWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFloatWithParam(_deckLinkConfiguration,
+                                 (BMDDeckLinkConfigurationID)configurationID,
+                                 (uint64_t)param,
+                                 error,
+                                 __PRETTY_FUNCTION__,
+                                 __LINE__,
+                                 @"IDeckLinkConfiguration::GetFloatWithParam failed.");
 }
 
 - (NSString*) stringValueForConfiguration:(DLABConfiguration)configurationID
                                 withParam:(NSUInteger)param
                                     error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    CFStringRef newStringValue = NULL;
-    result = _deckLinkConfiguration->GetStringWithParam(conf, (uint64_t)param, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::GetStringWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringWithParam(_deckLinkConfiguration,
+                                  (BMDDeckLinkConfigurationID)configurationID,
+                                  (uint64_t)param,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkConfiguration::GetStringWithParam failed.");
 }
 
 /* =================================================================================== */
@@ -1309,19 +1184,13 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    bool newBoolValue = (bool)value;
-    result = _deckLinkConfiguration->SetFlag(conf, newBoolValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetFlag failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetFlagValue(_deckLinkConfiguration,
+                            (BMDDeckLinkConfigurationID)configurationID,
+                            (bool)value,
+                            error,
+                            __PRETTY_FUNCTION__,
+                            __LINE__,
+                            @"IDeckLinkConfiguration::SetFlag failed.");
 }
 
 - (BOOL) setIntValue:(NSInteger)value forConfiguration:(DLABConfiguration)
@@ -1333,19 +1202,13 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    int64_t newIntValue = (int64_t)value;
-    result = _deckLinkConfiguration->SetInt(conf, newIntValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetInt failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetIntValue(_deckLinkConfiguration,
+                           (BMDDeckLinkConfigurationID)configurationID,
+                           (int64_t)value,
+                           error,
+                           __PRETTY_FUNCTION__,
+                           __LINE__,
+                           @"IDeckLinkConfiguration::SetInt failed.");
 }
 
 - (BOOL) setDoubleValue:(double_t)value forConfiguration:(DLABConfiguration)
@@ -1357,19 +1220,13 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    double newDoubleValue = (double)value;
-    result = _deckLinkConfiguration->SetFloat(conf, newDoubleValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetFloat failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetFloatValue(_deckLinkConfiguration,
+                             (BMDDeckLinkConfigurationID)configurationID,
+                             (double)value,
+                             error,
+                             __PRETTY_FUNCTION__,
+                             __LINE__,
+                             @"IDeckLinkConfiguration::SetFloat failed.");
 }
 
 - (BOOL) setStringValue:(NSString*)value forConfiguration:(DLABConfiguration)
@@ -1383,20 +1240,13 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    CFStringRef newStringValue = (CFStringRef)CFBridgingRetain(value);
-    result = _deckLinkConfiguration->SetString(conf, newStringValue);
-    CFRelease(newStringValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetString failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetStringValue(_deckLinkConfiguration,
+                              (BMDDeckLinkConfigurationID)configurationID,
+                              value,
+                              error,
+                              __PRETTY_FUNCTION__,
+                              __LINE__,
+                              @"IDeckLinkConfiguration::SetString failed.");
 }
 
 - (BOOL) setBoolValue:(BOOL)value
@@ -1410,19 +1260,14 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    bool newBoolValue = (bool)value;
-    result = _deckLinkConfiguration->SetFlagWithParam(conf, (uint64_t)param, newBoolValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetFlagWithParam failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetFlagWithParam(_deckLinkConfiguration,
+                                (BMDDeckLinkConfigurationID)configurationID,
+                                (uint64_t)param,
+                                (bool)value,
+                                error,
+                                __PRETTY_FUNCTION__,
+                                __LINE__,
+                                @"IDeckLinkConfiguration::SetFlagWithParam failed.");
 }
 
 - (BOOL) setIntValue:(NSInteger)value
@@ -1436,19 +1281,14 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    int64_t newIntValue = (int64_t)value;
-    result = _deckLinkConfiguration->SetIntWithParam(conf, (uint64_t)param, newIntValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetIntWithParam failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetIntWithParam(_deckLinkConfiguration,
+                               (BMDDeckLinkConfigurationID)configurationID,
+                               (uint64_t)param,
+                               (int64_t)value,
+                               error,
+                               __PRETTY_FUNCTION__,
+                               __LINE__,
+                               @"IDeckLinkConfiguration::SetIntWithParam failed.");
 }
 
 - (BOOL) setDoubleValue:(double_t)value
@@ -1462,19 +1302,14 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    double newDoubleValue = (double)value;
-    result = _deckLinkConfiguration->SetFloatWithParam(conf, (uint64_t)param, newDoubleValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetFloatWithParam failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetFloatWithParam(_deckLinkConfiguration,
+                                 (BMDDeckLinkConfigurationID)configurationID,
+                                 (uint64_t)param,
+                                 (double)value,
+                                 error,
+                                 __PRETTY_FUNCTION__,
+                                 __LINE__,
+                                 @"IDeckLinkConfiguration::SetFloatWithParam failed.");
 }
 
 - (BOOL) setStringValue:(NSString*)value
@@ -1490,20 +1325,14 @@ configurationID error:(NSError**)error
         return NO;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkConfigurationID conf = configurationID;
-    CFStringRef newStringValue = (CFStringRef)CFBridgingRetain(value);
-    result = _deckLinkConfiguration->SetStringWithParam(conf, (uint64_t)param, newStringValue);
-    CFRelease(newStringValue);
-    if (!result) {
-        return YES;
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkConfiguration::SetStringWithParam failed."
-              code:result
-                to:error];
-        return NO;
-    }
+    return DLABSetStringWithParam(_deckLinkConfiguration,
+                                  (BMDDeckLinkConfigurationID)configurationID,
+                                  (uint64_t)param,
+                                  value,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkConfiguration::SetStringWithParam failed.");
 }
 
 - (BOOL) writeConfigurationToPreferencesWithError:(NSError**)error
@@ -1534,73 +1363,45 @@ configurationID error:(NSError**)error
 - (NSNumber*) boolValueForStatus:(DLABDeckLinkStatus)statusID
                            error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    bool newBoolValue = false;
-    result = _deckLinkStatus->GetFlag(stat, &newBoolValue);
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetFlag failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFlagValue(_deckLinkStatus,
+                            (BMDDeckLinkStatusID)statusID,
+                            error,
+                            __PRETTY_FUNCTION__,
+                            __LINE__,
+                            @"IDeckLinkStatus::GetFlag failed.");
 }
 
 - (NSNumber*) intValueForStatus:(DLABDeckLinkStatus)statusID
                           error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    int64_t newIntValue = 0;
-    result = _deckLinkStatus->GetInt(stat, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetInt failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntValue(_deckLinkStatus,
+                           (BMDDeckLinkStatusID)statusID,
+                           error,
+                           __PRETTY_FUNCTION__,
+                           __LINE__,
+                           @"IDeckLinkStatus::GetInt failed.");
 }
 
 - (NSNumber*) doubleValueForStatus:(DLABDeckLinkStatus)statusID
                              error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    double newDoubleValue = 0;
-    result = _deckLinkStatus->GetFloat(stat, &newDoubleValue);
-    if (!result) {
-        return @(newDoubleValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetFloat failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFloatValue(_deckLinkStatus,
+                             (BMDDeckLinkStatusID)statusID,
+                             error,
+                             __PRETTY_FUNCTION__,
+                             __LINE__,
+                             @"IDeckLinkStatus::GetFloat failed.");
 }
 
 - (NSString*) stringValueForStatus:(DLABDeckLinkStatus)statusID
                              error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    CFStringRef newStringValue = NULL;
-    result = _deckLinkStatus->GetString(stat, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetString failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringValue(_deckLinkStatus,
+                              (BMDDeckLinkStatusID)statusID,
+                              error,
+                              __PRETTY_FUNCTION__,
+                              __LINE__,
+                              @"IDeckLinkStatus::GetString failed.");
 }
 
 - (NSMutableData*) dataValueForStatus:(DLABDeckLinkStatus)statusID
@@ -1650,76 +1451,52 @@ configurationID error:(NSError**)error
                        withParam:(NSUInteger)param
                            error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    bool newBoolValue = false;
-    result = _deckLinkStatus->GetFlagWithParam(stat, (uint64_t)param, &newBoolValue);
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetFlagWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFlagWithParam(_deckLinkStatus,
+                                (BMDDeckLinkStatusID)statusID,
+                                (uint64_t)param,
+                                error,
+                                __PRETTY_FUNCTION__,
+                                __LINE__,
+                                @"IDeckLinkStatus::GetFlagWithParam failed.");
 }
 
 - (NSNumber*) intValueForStatus:(DLABDeckLinkStatus)statusID
                       withParam:(NSUInteger)param
                           error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    int64_t newIntValue = 0;
-    result = _deckLinkStatus->GetIntWithParam(stat, (uint64_t)param, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetIntWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntWithParam(_deckLinkStatus,
+                               (BMDDeckLinkStatusID)statusID,
+                               (uint64_t)param,
+                               error,
+                               __PRETTY_FUNCTION__,
+                               __LINE__,
+                               @"IDeckLinkStatus::GetIntWithParam failed.");
 }
 
 - (NSNumber*) doubleValueForStatus:(DLABDeckLinkStatus)statusID
                          withParam:(NSUInteger)param
                              error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    double newDoubleValue = 0;
-    result = _deckLinkStatus->GetFloatWithParam(stat, (uint64_t)param, &newDoubleValue);
-    if (!result) {
-        return @(newDoubleValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetFloatWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFloatWithParam(_deckLinkStatus,
+                                 (BMDDeckLinkStatusID)statusID,
+                                 (uint64_t)param,
+                                 error,
+                                 __PRETTY_FUNCTION__,
+                                 __LINE__,
+                                 @"IDeckLinkStatus::GetFloatWithParam failed.");
 }
 
 - (NSString*) stringValueForStatus:(DLABDeckLinkStatus)statusID
                          withParam:(NSUInteger)param
                              error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatusID stat = statusID;
-    CFStringRef newStringValue = NULL;
-    result = _deckLinkStatus->GetStringWithParam(stat, (uint64_t)param, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatus::GetStringWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringWithParam(_deckLinkStatus,
+                                  (BMDDeckLinkStatusID)statusID,
+                                  (uint64_t)param,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkStatus::GetStringWithParam failed.");
 }
 
 - (NSMutableData*) dataValueForStatus:(DLABDeckLinkStatus)statusID
@@ -1779,19 +1556,12 @@ configurationID error:(NSError**)error
         return nil;
     }
     
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatisticID stat = statisticID;
-    int64_t newIntValue = 0;
-    result = _deckLinkStatistics->GetInt(stat, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatistics::GetInt failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntValue(_deckLinkStatistics,
+                           (BMDDeckLinkStatisticID)statisticID,
+                           error,
+                           __PRETTY_FUNCTION__,
+                           __LINE__,
+                           @"IDeckLinkStatistics::GetInt failed.");
 }
 
 - (NSNumber*) intValueForStatistic:(DLABDeckLinkStatistic)statisticID
@@ -1803,20 +1573,14 @@ configurationID error:(NSError**)error
                                          lineNumber:__LINE__]) {
         return nil;
     }
-
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatisticID stat = statisticID;
-    int64_t newIntValue = 0;
-    result = _deckLinkStatistics->GetIntWithParam(stat, (uint64_t)param, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatistics::GetIntWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    
+    return DLABGetIntWithParam(_deckLinkStatistics,
+                               (BMDDeckLinkStatisticID)statisticID,
+                               (uint64_t)param,
+                               error,
+                               __PRETTY_FUNCTION__,
+                               __LINE__,
+                               @"IDeckLinkStatistics::GetIntWithParam failed.");
 }
 
 - (NSString*) stringValueForStatistic:(DLABDeckLinkStatistic)statisticID
@@ -1828,20 +1592,14 @@ configurationID error:(NSError**)error
                                          lineNumber:__LINE__]) {
         return nil;
     }
-
-    HRESULT result = E_FAIL;
-    BMDDeckLinkStatisticID stat = statisticID;
-    CFStringRef newStringValue = NULL;
-    result = _deckLinkStatistics->GetStringWithParam(stat, (uint64_t)param, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkStatistics::GetStringWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    
+    return DLABGetStringWithParam(_deckLinkStatistics,
+                                  (BMDDeckLinkStatisticID)statisticID,
+                                  (uint64_t)param,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkStatistics::GetStringWithParam failed.");
 }
 
 @end

--- a/Source/DLABFrameMetadata.mm
+++ b/Source/DLABFrameMetadata.mm
@@ -9,16 +9,14 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABFrameMetadata+Internal.h>
+#import <DLABBridgingSupport.h>
 #import <DLABQueryInterfaceAny.h>
 
 @implementation DLABFrameMetadata
 
 - (instancetype) init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    NSString *selectorString = NSStringFromSelector(@selector(initWithOutputFrame:));
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+    DLABRaiseUnavailableInit(self, @selector(initWithOutputFrame:));
     return nil;
 }
 

--- a/Source/DLABProfileAttributes.mm
+++ b/Source/DLABProfileAttributes.mm
@@ -9,16 +9,14 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABProfileAttributes+Internal.h>
+#import <DLABBridgingSupport.h>
 #include <DLABQueryInterfaceAny.h>
 
 @implementation DLABProfileAttributes
 
 - (instancetype) init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    NSString *selectorString = NSStringFromSelector(@selector(initWithProfile:));
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+    DLABRaiseUnavailableInit(self, @selector(initWithProfile:));
     return nil;
 }
 
@@ -220,18 +218,7 @@
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    if (error) {
-        if (!description) description = @"unknown description";
-        if (!failureReason) failureReason = @"unknown failureReason";
-        
-        NSString *domain = @"com.MyCometG3.DLABridging.ErrorDomain";
-        NSInteger code = (NSInteger)result;
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
-                                   NSLocalizedFailureReasonErrorKey : failureReason,};
-        *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
-        return YES;
-    }
-    return NO;
+    return DLABAssignError(error, description, failureReason, (NSInteger)result);
 }
 
 /* =================================================================================== */
@@ -241,92 +228,58 @@
 - (NSNumber*) boolValueForAttribute:(DLABAttribute) attributeID
                               error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    bool newBoolValue = false;
-    result = _attributes->GetFlag(attr, &newBoolValue);
-    if (!result) {
-        return @(newBoolValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetFlag failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFlagValue(_attributes,
+                            (BMDDeckLinkAttributeID)attributeID,
+                            error,
+                            __PRETTY_FUNCTION__,
+                            __LINE__,
+                            @"IDeckLinkAttributes::GetFlag failed.");
 }
 
 - (NSNumber*) intValueForAttribute:(DLABAttribute) attributeID
                              error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    int64_t newIntValue = 0;
-    result = _attributes->GetInt(attr, &newIntValue);
-    if (!result) {
-        return @(newIntValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetInt failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetIntValue(_attributes,
+                           (BMDDeckLinkAttributeID)attributeID,
+                           error,
+                           __PRETTY_FUNCTION__,
+                           __LINE__,
+                           @"IDeckLinkAttributes::GetInt failed.");
 }
 
 - (NSNumber*) doubleValueForAttribute:(DLABAttribute) attributeID
                                 error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    double newDoubleValue = 0;
-    result = _attributes->GetFloat(attr, &newDoubleValue);
-    if (!result) {
-        return @(newDoubleValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetFloat failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetFloatValue(_attributes,
+                             (BMDDeckLinkAttributeID)attributeID,
+                             error,
+                             __PRETTY_FUNCTION__,
+                             __LINE__,
+                             @"IDeckLinkAttributes::GetFloat failed.");
 }
 
 - (NSString*) stringValueForAttribute:(DLABAttribute) attributeID
                                 error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    CFStringRef newStringValue = NULL;
-    result = _attributes->GetString(attr, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetString failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringValue(_attributes,
+                              (BMDDeckLinkAttributeID)attributeID,
+                              error,
+                              __PRETTY_FUNCTION__,
+                              __LINE__,
+                              @"IDeckLinkAttributes::GetString failed.");
 }
 
 - (NSString*) stringValueForAttribute:(DLABAttribute) attributeID
                             withParam:(NSUInteger)param
                                 error:(NSError**)error
 {
-    HRESULT result = E_FAIL;
-    BMDDeckLinkAttributeID attr = attributeID;
-    CFStringRef newStringValue = NULL;
-    result = _attributes->GetStringWithParam(attr, (uint64_t)param, &newStringValue);
-    if (!result) {
-        return (NSString*)CFBridgingRelease(newStringValue);
-    } else {
-        [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-            reason:@"IDeckLinkAttributes::GetStringWithParam failed."
-              code:result
-                to:error];
-        return nil;
-    }
+    return DLABGetStringWithParam(_attributes,
+                                  (BMDDeckLinkAttributeID)attributeID,
+                                  (uint64_t)param,
+                                  error,
+                                  __PRETTY_FUNCTION__,
+                                  __LINE__,
+                                  @"IDeckLinkAttributes::GetStringWithParam failed.");
 }
 
 @end

--- a/Source/DLABTimecodeSetting.mm
+++ b/Source/DLABTimecodeSetting.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABTimecodeSetting+Internal.h>
+#import <DLABBridgingSupport.h>
 
 @implementation DLABTimecodeSetting
 
@@ -171,18 +172,7 @@
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    if (error) {
-        if (!description) description = @"unknown description";
-        if (!failureReason) failureReason = @"unknown failureReason";
-        
-        NSString *domain = @"com.MyCometG3.DLABridging.ErrorDomain";
-        NSInteger code = (NSInteger)result;
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
-                                   NSLocalizedFailureReasonErrorKey : failureReason,};
-        *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
-        return YES;
-    }
-    return NO;
+    return DLABAssignError(error, description, failureReason, (NSInteger)result);
 }
 
 /* =================================================================================== */

--- a/Source/DLABVersionChecker.mm
+++ b/Source/DLABVersionChecker.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABVersionChecker.h>
+#import <DLABBridgingSupport.h>
 #import <DLABConstants.h>
 #import <DeckLinkAPI.h>
 
@@ -86,9 +87,7 @@
 
 - (instancetype)init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[%@ sharedChecker] instead", classString];
+    DLABRaiseUnavailableSingletonInit(self, @"sharedChecker");
     return nil;
 }
 

--- a/Source/DLABVideoBufferSupport.h
+++ b/Source/DLABVideoBufferSupport.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <CoreVideo/CoreVideo.h>
+#import <DeckLinkAPI.h>
+
+#include <math.h>
+
+NS_INLINE size_t pixelSizeForDL(IDeckLinkVideoFrame* videoFrame)
+{
+    size_t pixelSize = 0;   // For vImageCopyBuffer()
+    
+    BMDPixelFormat format = videoFrame->GetPixelFormat();
+    switch (format) {
+        case bmdFormat8BitYUV:
+            pixelSize = ceil(4.0 / 2); break; // 4 bytes 2 pixels block
+        case bmdFormat10BitYUV:
+            pixelSize = ceil(16.0 / 6); break; // 16 bytes 6 pixels block
+        case bmdFormat8BitARGB:
+            pixelSize = ceil(4.0 / 1); break; // 4 bytes 1 pixel block
+        case bmdFormat8BitBGRA:
+            pixelSize = ceil(4.0 / 1); break; // 4 bytes 1 pixel block
+        case bmdFormat10BitRGB:
+            pixelSize = ceil(4.0 / 1); break; // 4 bytes 1 pixel block
+        case bmdFormat12BitRGB:
+            pixelSize = ceil(36.0 / 8); break; // 36 bytes 8 pixel block
+        case bmdFormat12BitRGBLE:
+            pixelSize = ceil(36.0 / 8); break; // 36 bytes 8 pixel block
+        case bmdFormat10BitRGBXLE:
+            pixelSize = ceil(4.0 / 1); break; // 4 bytes 1 pixel block
+        case bmdFormat10BitRGBX:
+            pixelSize = ceil(4.0 / 1); break; // 4 bytes 1 pixel block
+        default:
+            break;
+    }
+    return pixelSize;
+}
+
+NS_INLINE size_t pixelSizeForCV(CVPixelBufferRef pixelBuffer)
+{
+    size_t pixelSize = 0;   // For vImageCopyBuffer()
+    {
+        NSString* kBitsPerBlock = (__bridge NSString*)kCVPixelFormatBitsPerBlock;
+        NSString* kBlockWidth = (__bridge NSString*)kCVPixelFormatBlockWidth;
+        NSString* kBlockHeight = (__bridge NSString*)kCVPixelFormatBlockHeight;
+        
+        OSType pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);
+        CFDictionaryRef pfDict = CVPixelFormatDescriptionCreateWithPixelFormatType(kCFAllocatorDefault, pixelFormat);
+        NSDictionary* dict = CFBridgingRelease(pfDict);
+        
+        int numBitsPerBlock = ((NSNumber*)dict[kBitsPerBlock]).intValue;
+        int numWidthPerBlock = MAX(1, ((NSNumber*)dict[kBlockWidth]).intValue);
+        int numHeightPerBlock = MAX(1, ((NSNumber*)dict[kBlockHeight]).intValue);
+        int numPixelPerBlock = numWidthPerBlock * numHeightPerBlock;
+        if (numPixelPerBlock) {
+            pixelSize = ceil(numBitsPerBlock / numPixelPerBlock / 8.0);
+        }
+    }
+    return pixelSize;
+}
+
+NS_INLINE BOOL VideoBufferLockBaseAddress(IDeckLinkVideoFrame* videoFrame,
+                                          BMDBufferAccessFlags accessFlags,
+                                          IDeckLinkVideoBuffer** outVideoBuffer)
+{
+    if (!videoFrame || !outVideoBuffer) return NO;
+    *outVideoBuffer = NULL;
+    
+    IDeckLinkVideoBuffer* buf = NULL;
+    HRESULT hr = videoFrame->QueryInterface(IID_IDeckLinkVideoBuffer, (void**)&buf);
+    if (FAILED(hr)) return NO;
+    
+    hr = buf->StartAccess(accessFlags);
+    if (FAILED(hr)) {
+        buf->Release();
+        return NO;
+    }
+    
+    *outVideoBuffer = buf; // caller owns one ref
+    return YES;
+}
+
+NS_INLINE BOOL VideoBufferGetBaseAddress(IDeckLinkVideoBuffer* videoBuffer, void** pointer)
+{
+    if (!videoBuffer || !pointer) return NO;
+    *pointer = NULL;
+    
+    HRESULT hr = videoBuffer->GetBytes(pointer);
+    return SUCCEEDED(hr) && (*pointer != NULL);
+}
+
+NS_INLINE void VideoBufferUnlockBaseAddress(IDeckLinkVideoBuffer* videoBuffer,
+                                            BMDBufferAccessFlags accessFlags)
+{
+    if (!videoBuffer) return;
+    (void)videoBuffer->EndAccess(accessFlags);
+    videoBuffer->Release();
+}

--- a/Source/DLABVideoConverter.mm
+++ b/Source/DLABVideoConverter.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABVideoConverter.h>
+#import <DLABVideoBufferSupport.h>
 
 /* =================================================================================== */
 // MARK: -
@@ -1219,45 +1220,6 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
         }
     }
     return convErr;
-}
-
-/* =================================================================================== */
-// MARK: DL VideoBuffer Lock/Unlock Base Address (SDK 14.3 or later)
-/* =================================================================================== */
-
-NS_INLINE BOOL VideoBufferLockBaseAddress(IDeckLinkVideoFrame* videoFrame,
-                                          BMDBufferAccessFlags accessFlags,
-                                          IDeckLinkVideoBuffer** outVideoBuffer) {
-    if (!videoFrame || !outVideoBuffer) return NO;
-    *outVideoBuffer = NULL;
-    
-    IDeckLinkVideoBuffer* buf = NULL;
-    HRESULT hr = videoFrame->QueryInterface(IID_IDeckLinkVideoBuffer, (void**)&buf);
-    if (FAILED(hr)) return NO;
-    
-    hr = buf->StartAccess(accessFlags);
-    if (FAILED(hr)) {
-        buf->Release();
-        return NO;
-    }
-    
-    *outVideoBuffer = buf; // caller owns one ref
-    return YES;
-}
-
-NS_INLINE BOOL VideoBufferGetBaseAddress(IDeckLinkVideoBuffer* videoBuffer, void** pointer) {
-    if (!videoBuffer || !pointer) return NO;
-    *pointer = NULL;
-    
-    HRESULT hr = videoBuffer->GetBytes(pointer);
-    return SUCCEEDED(hr) && (*pointer != NULL);
-}
-
-NS_INLINE void VideoBufferUnlockBaseAddress(IDeckLinkVideoBuffer* videoBuffer,
-                                            BMDBufferAccessFlags accessFlags) {
-    if (!videoBuffer) return;
-    (void)videoBuffer->EndAccess(accessFlags);
-    videoBuffer->Release();
 }
 
 /* =================================================================================== */

--- a/Source/DLABVideoSetting.mm
+++ b/Source/DLABVideoSetting.mm
@@ -9,6 +9,7 @@
 /* This software is released under the MIT License, see LICENSE.txt. */
 
 #import <DLABVideoSetting+Internal.h>
+#import <DLABBridgingSupport.h>
 
 NS_INLINE long rowBytesFor(BMDPixelFormat pixelFormat, long width) {
     long stride = 0;
@@ -235,10 +236,7 @@ NS_INLINE BOOL checkPixelFormat(BMDPixelFormat dlPixelFormat, OSType cvPixelForm
 
 - (instancetype) init
 {
-    NSString *classString = NSStringFromClass([self class]);
-    NSString *selectorString = NSStringFromSelector(@selector(initWithDisplayModeObj:));
-    [NSException raise:NSGenericException
-                format:@"Disabled. Use +[[%@ alloc] %@] instead", classString, selectorString];
+    DLABRaiseUnavailableInit(self, @selector(initWithDisplayModeObj:));
     return nil;
 }
 
@@ -434,18 +432,7 @@ NS_INLINE BOOL checkPixelFormat(BMDPixelFormat dlPixelFormat, OSType cvPixelForm
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    if (error) {
-        if (!description) description = @"unknown description";
-        if (!failureReason) failureReason = @"unknown failureReason";
-        
-        NSString *domain = @"com.MyCometG3.DLABridging.ErrorDomain";
-        NSInteger code = (NSInteger)result;
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description,
-                                   NSLocalizedFailureReasonErrorKey : failureReason,};
-        *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
-        return YES;
-    }
-    return NO;
+    return DLABAssignError(error, description, failureReason, (NSInteger)result);
 }
 
 /* =================================================================================== */


### PR DESCRIPTION
## Summary
- port the DLAB refactor from eb07870a90cbcbbf6b4023b22194d2d3a3854d96 into the standalone DLABridging workspace project
- add DLABBridgingSupport.h and DLABVideoBufferSupport.h to the Xcode project so angle-bracket imports resolve correctly
- keep the workspace source aligned with the refactored helper usage introduced in DLAB

## Validation
- xcodebuild -project DLABridging.xcodeproj -scheme DLABridging -configuration Debug build CODE_SIGNING_ALLOWED=NO